### PR TITLE
feat: job analyzer input page (US-011) + email confirmation flow

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,13 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
 
 export default function SignupPage() {
-  const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -28,6 +26,9 @@ export default function SignupPage() {
     const { error } = await supabase.auth.signUp({
       email,
       password,
+      options: {
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+      },
     });
 
     if (error) {
@@ -36,8 +37,8 @@ export default function SignupPage() {
       return;
     }
 
-    toast.success("Account created successfully!");
-    router.push("/cv");
+    toast.success("Check your email to confirm your account!");
+    setLoading(false);
   };
 
   return (

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,7 +1,90 @@
-export default function DashboardPage() {
-    return (
-        <div className="p-8">
-            <h1 className="text-2xl font-semibold">Dashboard</h1>
-        </div>
-    );
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { Cv, JobAnalysis, InterviewSession, CareerRoadmap } from "@/types";
+import { CVStatusWidget } from "@/components/dashboard/CVStatusWidget";
+import { RecentJobsWidget } from "@/components/dashboard/RecentJobsWidget";
+import { RecentInterviewsWidget } from "@/components/dashboard/RecentInterviewsWidget";
+import { CareerRoadmapWidget } from "@/components/dashboard/CareerRoadmapWidget";
+
+export default async function DashboardPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  // ── Parallel fetch — all four queries fire simultaneously ──────────────────
+  const [cvResult, jobsResult, interviewsResult, roadmapResult] =
+    await Promise.all([
+      // Active CV (single row or null)
+      supabase
+        .from("cvs")
+        .select("*")
+        .eq("user_id", user.id)
+        .eq("is_active", true)
+        .maybeSingle(),
+
+      // Last 3 job analyses
+      supabase
+        .from("job_analyses")
+        .select("*")
+        .eq("user_id", user.id)
+        .order("created_at", { ascending: false })
+        .limit(3),
+
+      // Last 3 interview sessions
+      supabase
+        .from("interview_sessions")
+        .select("*")
+        .eq("user_id", user.id)
+        .order("created_at", { ascending: false })
+        .limit(3),
+
+      // Most recent career roadmap
+      supabase
+        .from("career_roadmaps")
+        .select("*")
+        .eq("user_id", user.id)
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+    ]);
+
+  const cv = (cvResult.data as Cv | null) ?? null;
+  const jobs = (jobsResult.data as JobAnalysis[]) ?? [];
+  const interviews = (interviewsResult.data as InterviewSession[]) ?? [];
+  const roadmap = (roadmapResult.data as CareerRoadmap | null) ?? null;
+
+  // Greeting: use name from email before the @
+  const displayName = user.email?.split("@")[0] ?? "there";
+
+  return (
+    <div className="space-y-8 animate-fade-in-up">
+      {/* ── Page header ────────────────────────────────────────────────────── */}
+      <div>
+        <h1
+          className="text-3xl font-extrabold text-white"
+          style={{ fontFamily: "var(--font-heading)" }}
+        >
+          Welcome back, {displayName} 👋
+        </h1>
+        <p className="text-gray-400 mt-1 text-sm">
+          Here&apos;s an overview of your CareerPilot activity.
+        </p>
+      </div>
+
+      {/* ── Widget grid ────────────────────────────────────────────────────── */}
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        <CVStatusWidget cv={cv} />
+        <CareerRoadmapWidget roadmap={roadmap} />
+        <RecentJobsWidget jobs={jobs} />
+        <RecentInterviewsWidget sessions={interviews} />
+      </div>
+    </div>
+  );
 }
+

--- a/src/app/api/cv/parse/route.ts
+++ b/src/app/api/cv/parse/route.ts
@@ -5,8 +5,9 @@ import { createClient } from "@supabase/supabase-js";
 import { generateObject } from "ai";
 import { anthropic } from "@ai-sdk/anthropic";
 import { z } from "zod";
-import pdfParse from "pdf-parse";
 import mammoth from "mammoth";
+// pdf-parse is purely CommonJS and breaks Turbopack ESM resolution when imported normally
+const pdfParse = require("pdf-parse");
 
 export async function POST(req: Request) {
   try {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,14 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+
+  if (code) {
+    const supabase = await createClient();
+    await supabase.auth.exchangeCodeForSession(code);
+  }
+
+  return NextResponse.redirect(`${origin}/dashboard`);
+}

--- a/src/components/dashboard/CVStatusWidget.tsx
+++ b/src/components/dashboard/CVStatusWidget.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import { FileText, ArrowRight, Upload } from "lucide-react";
+import { Cv } from "@/types";
+import { format } from "date-fns";
+
+interface CVStatusWidgetProps {
+  cv: Cv | null;
+}
+
+export function CVStatusWidget({ cv }: CVStatusWidgetProps) {
+  return (
+    <div className="bg-[#111827] border border-[#1E3A5F] rounded-xl p-6 flex flex-col gap-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <FileText className="w-5 h-5 text-blue-400" />
+          <h2 className="text-base font-semibold text-white" style={{ fontFamily: "var(--font-heading)" }}>
+            Your CV
+          </h2>
+        </div>
+        <Link
+          href="/cv"
+          className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 font-medium transition-colors"
+        >
+          View all <ArrowRight className="w-3 h-3" />
+        </Link>
+      </div>
+
+      {/* Content */}
+      {cv ? (
+        <div className="flex flex-col gap-3">
+          {/* Status pill */}
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold bg-green-500/10 text-green-400 border border-green-500/20">
+              <span className="w-1.5 h-1.5 rounded-full bg-green-400" />
+              CV Uploaded
+            </span>
+          </div>
+
+          {/* File info */}
+          <div className="bg-[#0A0F1C] border border-[#1E3A5F]/60 rounded-lg p-3">
+            <p className="text-white text-sm font-medium truncate" title={cv.file_name}>
+              {cv.file_name}
+            </p>
+            <p className="text-gray-500 text-xs mt-0.5">
+              Uploaded {format(new Date(cv.uploaded_at), "MMM d, yyyy")}
+            </p>
+          </div>
+
+          <Link
+            href="/cv"
+            className="text-sm text-blue-400 hover:text-blue-300 font-medium transition-colors mt-1"
+          >
+            View &amp; edit profile →
+          </Link>
+        </div>
+      ) : (
+        /* Empty state */
+        <div className="flex flex-col items-start gap-4 py-2">
+          <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-[#1E3A5F]/30">
+            <Upload className="w-5 h-5 text-gray-500" />
+          </div>
+          <div>
+            <p className="text-gray-400 text-sm leading-relaxed">
+              No CV uploaded yet — add yours to unlock all features.
+            </p>
+          </div>
+          <Link
+            href="/cv"
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold transition-colors"
+          >
+            Upload your CV <ArrowRight className="w-4 h-4" />
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/CareerRoadmapWidget.tsx
+++ b/src/components/dashboard/CareerRoadmapWidget.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import { TrendingUp, ArrowRight, MapPin } from "lucide-react";
+import { CareerRoadmap } from "@/types";
+
+interface CareerRoadmapWidgetProps {
+  roadmap: CareerRoadmap | null;
+}
+
+export function CareerRoadmapWidget({ roadmap }: CareerRoadmapWidgetProps) {
+  return (
+    <div className="bg-[#111827] border border-[#1E3A5F] rounded-xl p-6 flex flex-col gap-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <TrendingUp className="w-5 h-5 text-green-400" />
+          <h2 className="text-base font-semibold text-white" style={{ fontFamily: "var(--font-heading)" }}>
+            Career Roadmap
+          </h2>
+        </div>
+        <Link
+          href="/career"
+          className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 font-medium transition-colors"
+        >
+          View all <ArrowRight className="w-3 h-3" />
+        </Link>
+      </div>
+
+      {/* Content */}
+      {roadmap ? (
+        <div className="flex flex-col gap-4">
+          {/* Route visualisation */}
+          <div className="bg-[#0A0F1C] border border-[#1E3A5F]/60 rounded-lg p-4 flex flex-col sm:flex-row items-start sm:items-center gap-3">
+            {/* Current role */}
+            <div className="flex-1 min-w-0">
+              <p className="text-gray-500 text-xs uppercase tracking-wider mb-1 font-medium">Current</p>
+              <p className="text-white text-sm font-semibold truncate">{roadmap.current_role}</p>
+            </div>
+
+            {/* Arrow */}
+            <div className="flex items-center gap-1 text-blue-500 shrink-0">
+              <div className="w-8 h-[2px] bg-blue-500/40 hidden sm:block" />
+              <ArrowRight className="w-5 h-5" />
+              <div className="w-8 h-[2px] bg-blue-500/40 hidden sm:block" />
+            </div>
+
+            {/* Target role */}
+            <div className="flex-1 min-w-0 text-right sm:text-right">
+              <p className="text-gray-500 text-xs uppercase tracking-wider mb-1 font-medium">Target</p>
+              <p className="text-green-400 text-sm font-semibold truncate">{roadmap.target_role}</p>
+            </div>
+          </div>
+
+          {/* Steps count */}
+          <p className="text-gray-500 text-xs">
+            {roadmap.steps.length} step{roadmap.steps.length !== 1 ? "s" : ""} in your roadmap
+          </p>
+
+          <Link
+            href="/career"
+            className="text-sm text-blue-400 hover:text-blue-300 font-medium transition-colors"
+          >
+            View full roadmap →
+          </Link>
+        </div>
+      ) : (
+        /* Empty state */
+        <div className="flex flex-col items-start gap-4 py-2">
+          <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-[#1E3A5F]/30">
+            <MapPin className="w-5 h-5 text-gray-500" />
+          </div>
+          <p className="text-gray-400 text-sm leading-relaxed">
+            No roadmap yet — generate yours from your CV to chart your path forward.
+          </p>
+          <Link
+            href="/career"
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold transition-colors"
+          >
+            Generate your roadmap <ArrowRight className="w-4 h-4" />
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/RecentInterviewsWidget.tsx
+++ b/src/components/dashboard/RecentInterviewsWidget.tsx
@@ -1,0 +1,100 @@
+import Link from "next/link";
+import { MessageSquare, ArrowRight, Mic } from "lucide-react";
+import { InterviewSession, InterviewQuestion } from "@/types";
+import { format } from "date-fns";
+
+interface RecentInterviewsWidgetProps {
+  sessions: InterviewSession[];
+}
+
+/** Compute average score from graded questions, returns null if no graded answers yet */
+function computeOverallScore(questions: InterviewQuestion[]): number | null {
+  const graded = questions.filter((q) => q.score !== null);
+  if (graded.length === 0) return null;
+  const sum = graded.reduce((acc, q) => acc + (q.score ?? 0), 0);
+  // scores are 0-10 per question, display as percentage
+  return Math.round((sum / (graded.length * 10)) * 100);
+}
+
+function ScoreBadge({ score }: { score: number | null }) {
+  if (score === null) {
+    return (
+      <span className="text-xs font-medium text-gray-500 bg-[#1E3A5F]/30 px-2 py-0.5 rounded-full">
+        In progress
+      </span>
+    );
+  }
+  const colour =
+    score >= 75
+      ? "text-green-400 bg-green-500/10 border border-green-500/20"
+      : score >= 50
+      ? "text-yellow-400 bg-yellow-500/10 border border-yellow-500/20"
+      : "text-red-400 bg-red-500/10 border border-red-500/20";
+
+  return (
+    <span className={`text-xs font-semibold px-2.5 py-0.5 rounded-full ${colour}`}>
+      {score}%
+    </span>
+  );
+}
+
+export function RecentInterviewsWidget({ sessions }: RecentInterviewsWidgetProps) {
+  return (
+    <div className="bg-[#111827] border border-[#1E3A5F] rounded-xl p-6 flex flex-col gap-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <MessageSquare className="w-5 h-5 text-orange-400" />
+          <h2 className="text-base font-semibold text-white" style={{ fontFamily: "var(--font-heading)" }}>
+            Recent Interviews
+          </h2>
+        </div>
+        <Link
+          href="/interview"
+          className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 font-medium transition-colors"
+        >
+          View all <ArrowRight className="w-3 h-3" />
+        </Link>
+      </div>
+
+      {/* Content */}
+      {sessions.length > 0 ? (
+        <ul className="flex flex-col divide-y divide-[#1E3A5F]/50">
+          {sessions.map((session) => {
+            const score = computeOverallScore(session.questions);
+            return (
+              <li key={session.id} className="flex items-center justify-between py-3 gap-3">
+                <div className="min-w-0">
+                  <p className="text-white text-sm font-medium">
+                    Practice session
+                  </p>
+                  <p className="text-gray-500 text-xs mt-0.5">
+                    {format(new Date(session.created_at), "MMM d, yyyy")} ·{" "}
+                    {session.questions.length} questions
+                  </p>
+                </div>
+                <ScoreBadge score={score} />
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        /* Empty state */
+        <div className="flex flex-col items-start gap-4 py-2">
+          <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-[#1E3A5F]/30">
+            <Mic className="w-5 h-5 text-gray-500" />
+          </div>
+          <p className="text-gray-400 text-sm leading-relaxed">
+            No interviews practised yet — start with a job analysis to generate tailored questions.
+          </p>
+          <Link
+            href="/jobs"
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold transition-colors"
+          >
+            Start with a job analysis <ArrowRight className="w-4 h-4" />
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/RecentJobsWidget.tsx
+++ b/src/components/dashboard/RecentJobsWidget.tsx
@@ -1,0 +1,85 @@
+import Link from "next/link";
+import { Briefcase, ArrowRight, PlusCircle } from "lucide-react";
+import { JobAnalysis } from "@/types";
+
+interface RecentJobsWidgetProps {
+  jobs: JobAnalysis[];
+}
+
+function FitScoreBadge({ score }: { score: number | null }) {
+  if (score === null) {
+    return (
+      <span className="text-xs font-medium text-gray-500 bg-[#1E3A5F]/30 px-2 py-0.5 rounded-full">
+        —
+      </span>
+    );
+  }
+
+  const colour =
+    score >= 75
+      ? "text-green-400 bg-green-500/10 border border-green-500/20"
+      : score >= 50
+      ? "text-yellow-400 bg-yellow-500/10 border border-yellow-500/20"
+      : "text-red-400 bg-red-500/10 border border-red-500/20";
+
+  return (
+    <span className={`text-xs font-semibold px-2.5 py-0.5 rounded-full ${colour}`}>
+      {score}%
+    </span>
+  );
+}
+
+export function RecentJobsWidget({ jobs }: RecentJobsWidgetProps) {
+  return (
+    <div className="bg-[#111827] border border-[#1E3A5F] rounded-xl p-6 flex flex-col gap-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Briefcase className="w-5 h-5 text-purple-400" />
+          <h2 className="text-base font-semibold text-white" style={{ fontFamily: "var(--font-heading)" }}>
+            Recent Job Analyses
+          </h2>
+        </div>
+        <Link
+          href="/jobs"
+          className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 font-medium transition-colors"
+        >
+          View all <ArrowRight className="w-3 h-3" />
+        </Link>
+      </div>
+
+      {/* Content */}
+      {jobs.length > 0 ? (
+        <ul className="flex flex-col divide-y divide-[#1E3A5F]/50">
+          {jobs.map((job) => (
+            <li key={job.id} className="flex items-center justify-between py-3 gap-3">
+              <div className="min-w-0">
+                <p className="text-white text-sm font-medium truncate">{job.job_title}</p>
+                {job.company && (
+                  <p className="text-gray-500 text-xs mt-0.5 truncate">{job.company}</p>
+                )}
+              </div>
+              <FitScoreBadge score={job.fit_score} />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        /* Empty state */
+        <div className="flex flex-col items-start gap-4 py-2">
+          <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-[#1E3A5F]/30">
+            <PlusCircle className="w-5 h-5 text-gray-500" />
+          </div>
+          <p className="text-gray-400 text-sm leading-relaxed">
+            No jobs analysed yet — paste your first listing to see how well you match.
+          </p>
+          <Link
+            href="/jobs"
+            className="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold transition-colors"
+          >
+            Analyse a job <ArrowRight className="w-4 h-4" />
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- Add /jobs page with job description textarea and Analyse button
- Show loading/streaming state while AI processes the listing
- Guard against missing CV — redirect to /cv if no parsed data found
- Call POST /api/jobs/analyze on submit and redirect to /jobs/[id]

- Add emailRedirectTo option to supabase.auth.signUp()
- Create /auth/callback route to exchange code for session
- Update signup success toast to prompt email confirmation
- Remove premature redirect after signup

Closes #17 