### PR TITLE
fix: implement Tier 0 trust & foundation improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,17 @@ Schema file at project root: `schema.sql` (consolidated — safe to run on fresh
 - All AI calls use `anthropic("claude-haiku-4-5")`
 - All prompts are defined as exported functions in `src/lib/ai/prompts.ts`
 
+### Fit-Score Rubric (do not change without updating this doc)
+`buildJobAnalysisPrompt` uses a fixed banded rubric so scores are comparable across users and over time:
+- **90–100** — meets every requirement + most preferred, seniority match, direct domain experience
+- **75–89** — all hard reqs met, missing 1–2 preferred, seniority ±1
+- **60–74** — most hard reqs met, missing 1 critical OR seniority off by one level
+- **40–59** — plausible stretch, 2+ hard reqs missing or seniority off by 2 levels
+- **20–39** — significant gaps, likely fails resume screen
+- **0–19** — wrong role family or seniority tier entirely
+
+Within the chosen band, adjust ±5 for nuance. Do not inflate.
+
 ### Rate Limiting
 Two-tier system tracked via `rate_limit_events` table:
 - **Global:** 10 AI requests per hour per user

--- a/FEATURE_AUDIT.md
+++ b/FEATURE_AUDIT.md
@@ -1,0 +1,137 @@
+# CareerPilot — Feature Audit & Review Brief
+
+> Paste this file into a Claude.ai chat with Opus to get a product/feature review. It describes current state, known rough edges, and open questions — so the model can focus on suggesting what's missing rather than rediscovering what exists.
+
+---
+
+## 1. What the app is
+
+AI-powered career management platform. A logged-in user uploads their CV once, then every other feature is personalised to that CV. Target user: active job-seekers, especially technical ones, who want AI help across the whole loop (CV → job search → application → interview → career planning).
+
+**Monetisation / stage:** not stated — assume pre-revenue / MVP. Single-tenant Supabase.
+
+**Core loop that already works:** upload CV → parse to structured JSON → paste a job listing → get fit score + salary + skill gaps → generate tailored cover letter → run a mock interview → track the application.
+
+---
+
+## 2. Tech context (for grounding suggestions)
+
+- Next.js 16 App Router, React 19, TypeScript strict
+- Supabase (Postgres + Auth + Storage) with RLS on every table
+- Vercel AI SDK → Anthropic `claude-haiku-4-5` for all AI calls
+- Zod for request + AI-output validation
+- Rate limits per user: **10 AI calls/hour global**, plus `/cv/parse` 3/hr and `/cover-letter/generate` 5/hr
+- All prompts centralised in `src/lib/ai/prompts.ts`
+- 8 tables: `profiles`, `cvs`, `job_analyses`, `interview_sessions`, `career_roadmaps`, `cover_letters`, `applications`, `rate_limit_events`
+
+---
+
+## 3. The seven features — current state + rough edges
+
+### 3.1 CV Hub
+**What it does:** PDF/DOCX upload → text extraction (`pdf-parse` / `mammoth`) → Claude parses into `ParsedCvData` (role, seniority, years, skills[], education[], experience[], achievements[]). One CV is marked `is_active`; other features read from it.
+
+**Rough edges / gaps:**
+- Only **one active CV** at a time. No versioning, no per-role tailored variants ("CV for backend roles" vs "CV for platform roles").
+- Skills are a flat `string[]` — no categorisation (language / framework / tool / soft), no proficiency.
+- No "CV improvement" feature independent of a job (improvements only surface inside Job Analysis as `cv_suggestions`).
+- No LinkedIn import or "build CV from scratch" flow — user must already have a PDF.
+- PDF parsing relies on brittle DOMMatrix/DOMPoint polyfills for `pdfjs-dist` in Node.
+
+### 3.2 Job Analyzer
+**What it does:** user pastes `jobTitle` + optional `company` + raw job text. Returns `fit_score` 0–100, recommendation (`apply` / `maybe` / `skip`) with reason, `matched_skills`, `missing_skills`, 3–5 `cv_suggestions`, and a `salary_estimate` with factors + negotiation tip.
+
+**Rough edges / gaps:**
+- **Manual paste only.** No URL scraping, no LinkedIn/Indeed/Greenhouse integration, no browser extension.
+- No **cross-job comparison** — can't diff two listings or rank a batch.
+- Salary estimate is Claude-inferred from the listing; no real market data (Levels.fyi, Glassdoor).
+- No signal on **application competition** (how hot is this role) or **company health** (layoffs, growth).
+- No way to re-run analysis after editing the CV.
+
+### 3.3 Interview Coach
+**What it does:** generates 8–10 tailored questions (3 behavioural / 3–4 technical / 2–3 role-specific) for a given job analysis. User types answers; Claude streams feedback per answer using STAR evaluation for behavioural, plus a 0–100 score. Session has an `overall_score`.
+
+**Rough edges / gaps:**
+- **Text answers only** — no voice input, no speech-to-text, no pacing/filler-word analysis. Real interviews are spoken.
+- No **follow-up questions** — it's a flat list, not an adaptive interviewer that probes weak answers.
+- No **company-specific prep** (values, recent news, interviewer research).
+- No **system-design** or **live-coding** modes distinct from Q&A.
+- No retakes / progress-over-time tracking per question type.
+- STAR framework is hard-coded in the prompt — no coverage of CAR, SOAR, or role-specific frameworks (case study, PM product sense, etc.).
+
+### 3.4 Career Ladder
+**What it does:** given the active CV, Claude returns 3 distinct career paths (e.g. IC / Management / Specialised Pivot), each with `next_role`, `timeline_estimate`, `missing_skills`, `recommended_projects`, `experience_needed`.
+
+**Rough edges / gaps:**
+- No **progress tracking** — user can't mark a project done or a skill learned. Roadmap is a one-shot document, not a living plan.
+- No **resource links** — "learn Kubernetes" with no course/book/tutorial suggestions.
+- No **market demand signal** — which of the 3 paths is hottest in the user's region/salary band?
+- No **mentorship / role-model** layer (e.g. "people who made this jump came from X").
+- Only 3 paths, always — not configurable.
+
+### 3.5 Cover Letter Generator
+**What it does:** `generateText()` call (not structured) with a strong system prompt banning corporate filler. Produces 3–4 paragraphs under 400 words from CV + job. Export to PDF via `window.print`.
+
+**Rough edges / gaps:**
+- **One draft, take it or leave it.** No regenerate-this-paragraph, no tone variants (formal / warm / confident), no length options.
+- No **template library** or past-letter reuse.
+- No **user edits persisted** — if the user rewrites it, changes don't save back.
+- No per-company **memory** (if the user has applied to Stripe 3 times, nothing personalises).
+- PDF export is browser print — fine but no DOCX / plaintext-email formats.
+
+### 3.6 Application Tracker
+**What it does:** CRUD on `applications` with status enum (`saved` / `applied` / `interviewing` / `offered` / `rejected`). Links optionally to a `job_analysis` and a `cover_letter`. Free-text notes field.
+
+**Rough edges / gaps:**
+- No **reminders or follow-ups** — "it's been 14 days since you applied, ping them?"
+- No **interview date / time tracking** — the `interviewing` status is binary, not a schedule.
+- No **offer tracking** — compensation breakdown, deadline to respond, competing offers.
+- No **email/calendar integration** — user manually updates status.
+- No **timeline view / pipeline velocity** (e.g. "you average 8 days from applied → interview").
+- `notes` is one free-text blob — no structured contacts / recruiter / referral fields.
+
+### 3.7 Analytics
+**What it does:** single `AnalyticsClient.tsx` component. Likely counts across applications, interview scores, fit-score distribution. (Scope not fully inspected — ask if you want me to dig in.)
+
+**Rough edges / gaps (suspected):**
+- Probably descriptive ("you applied to 12 jobs") not prescriptive ("your fit scores drop for roles needing Go — learn Go or filter them out").
+- No **cohort benchmarks** (how does the user compare to similar job-seekers?) — though that needs scale.
+- No **funnel analysis** (applied → heard back → interview → offer rates).
+
+---
+
+## 4. Cross-cutting gaps worth discussing
+
+- **No job-board ingestion.** Everything starts with the user pasting text. A browser extension or URL scraper would 10x usage frequency.
+- **Single active CV = bottleneck** for anyone applying to diverse roles.
+- **No networking layer.** Referrals drive most hires; the app doesn't touch this.
+- **No negotiation coach.** Salary estimate exists at job-analysis time, but the offer stage (the moment money is actually won) has no support.
+- **No feedback loop from outcomes.** The app has parsed CVs + job analyses + application outcomes. It never closes the loop — "users with your profile got hired for role X" or "your fit-score predictions vs actual interview-invite rate."
+- **Model choice is fixed (Haiku).** No premium tier using Opus/Sonnet for deeper reasoning (interview critiques, roadmap quality).
+- **Rate limits may be tight for power users.** 5 cover letters/hour limits someone batch-applying on a Saturday.
+- **No shareable artifact.** User can't share a public portfolio / CV link / interview-readiness badge.
+- **No mobile-first flow.** This is a dashboard app; real job-seekers are often browsing listings on phones.
+
+---
+
+## 5. Tensions / strategic questions to challenge
+
+1. **7 features is a suite, not a wedge.** Which one is actually the reason a user opens the app on day 1? Everything else should funnel from that, and the current UI gives them equal weight on the sidebar.
+2. **Job trackers are a commodity** (Huntr, Teal, Simplify all exist). What's the defensible layer here — the AI quality, the CV→interview→analytics loop, or something else?
+3. **AI cost vs value per feature.** Cover-letter generation is arguably lowest-leverage (LLMs have commoditised it); interview prep with real feedback is probably highest. Is resource allocation reflecting that?
+4. **Who pays?** B2C job-seekers are a notoriously bad market (short use window, low willingness-to-pay). Is there a B2B angle — bootcamps, career coaches, university career services — that the current architecture could serve?
+5. **Data moat.** Every user generates parsed CV + job + outcome data. That's a training set / benchmarking goldmine that's currently not used for anything. Is that a v2 feature or a north star?
+
+---
+
+## 6. What I want from this review
+
+Please evaluate:
+
+1. **Feature prioritisation** — if I can only ship 2 new features in the next month, which of the gaps above (or new ones you'd add) have the best impact/effort ratio?
+2. **The wedge question** — which of the 7 existing features should be the hero / marketing front-door, and why? What would you cut or demote?
+3. **Moat / differentiation** — concrete suggestions for a feature that commodity trackers (Huntr, Teal) structurally can't copy.
+4. **The outcome-feedback loop** — specific, implementable ways to use application outcomes to improve future AI suggestions.
+5. **Anything I'm missing** — feel free to propose features I haven't listed. Bias toward ideas that use the unique data the app already has (parsed CV + job text + interview performance + application outcomes) rather than bolt-on LLM features anyone could add.
+
+Keep suggestions grounded: each idea should name a specific user action, the data it relies on, and why it's harder to copy than "add an AI button."

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,733 @@
+# CareerPilot — Prioritized Issues
+
+Each issue below is written as a standalone GitHub issue. Copy-paste the block under each heading into a new issue. Order matters: **ship Tier 0 before Tier 1 before Tier 2.** Within a tier, items can be parallelized.
+
+**Legend**
+- **Complexity:** S (≤1 day), M (2–5 days), L (1–2 weeks)
+- **Depends on:** issues that must ship first
+
+---
+
+## Tier 0 — Trust & Foundation
+
+Five issues. These don't add features — they make the features you already have actually trustworthy. Ship all of them before anything in Tier 1.
+
+---
+
+### [T0-1] Capture structured outcomes when application status changes
+
+**Tier:** 0 · **Complexity:** M · **Depends on:** —
+
+**Why**
+Every application outcome is currently a black box. A user moves an application to `rejected` and we learn nothing. Without captured outcomes, fit scores can't be calibrated, rejection post-mortems can't be written, and every "AI insight" stays a guess. This single change is the prerequisite for the entire Tier 2 moat.
+
+**What**
+- Extend the `applications` table with structured outcome fields.
+- When a user transitions an application to `interviewing`, `offered`, or `rejected`, show a small modal (2–3 questions max).
+- Store responses. No LLM involved yet — just capture.
+
+**Schema changes** (add to `schema.sql`):
+```sql
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS outcome_stage_reached TEXT,
+    -- 'no_response' | 'recruiter_screen' | 'phone_screen' | 'technical' | 'onsite' | 'offer'
+  ADD COLUMN IF NOT EXISTS outcome_reason TEXT,
+    -- free text, user-provided
+  ADD COLUMN IF NOT EXISTS outcome_fit_score_at_application INTEGER,
+    -- snapshot of job_analyses.fit_score when applied_at was set
+  ADD COLUMN IF NOT EXISTS outcome_captured_at TIMESTAMPTZ;
+```
+
+**Acceptance criteria**
+- [ ] Schema migration added (idempotent, safe re-run).
+- [ ] When status changes to `interviewing`, modal asks: "What stage did you reach?" (dropdown) + "Anything notable?" (optional text).
+- [ ] When status changes to `offered` or `rejected`, modal asks reason (optional) and confirms stage reached.
+- [ ] When `applied_at` is first set, snapshot the linked `job_analyses.fit_score` into `outcome_fit_score_at_application`.
+- [ ] Modal is skippable (user can dismiss) but re-promptable from the application detail view.
+- [ ] All new fields exposed in the `Application` TypeScript type.
+
+**Files to touch**
+- `schema.sql`
+- `src/types/index.ts`
+- `src/components/applications/*`
+- `src/app/api/applications/route.ts` (or wherever status updates happen)
+
+---
+
+### [T0-2] Add a calibration rubric to the fit-score prompt
+
+**Tier:** 0 · **Complexity:** S · **Depends on:** —
+
+**Why**
+The current prompt says "fit_score (0–100 integer) — genuine match quality, do not inflate". That's not a rubric — it's a plea. Scores aren't comparable across users or across weeks because there's no fixed reference frame. A candidate with 3/10 required skills might get 45 one day and 62 the next.
+
+**What**
+Replace the single line with a banded rubric anchored to specific conditions. The model will cluster outputs and scores become meaningful over time.
+
+**Proposed rubric to add in `buildJobAnalysisPrompt`:**
+
+```
+Use this fit_score rubric strictly. Pick the band the candidate fits, then adjust ±5 within it.
+
+  90–100  Meets every stated requirement + most preferred. Seniority match. Direct domain experience.
+  75–89   Meets all hard requirements. Missing 1–2 preferred. Seniority match or one level off.
+  60–74   Meets most hard requirements. Missing 1 critical hard requirement OR seniority off by one level.
+  40–59   Plausible stretch. Missing 2+ hard requirements or mismatched seniority by 2 levels.
+  20–39   Significant gaps. Would likely fail a resume screen.
+  0–19    Wrong role family or wrong seniority tier entirely.
+
+Before picking a band, list the hard requirements in the listing (as you understand them) and
+check them off against the candidate's skills and experience. Include this checklist in your
+internal reasoning but do NOT include it in the output.
+```
+
+**Acceptance criteria**
+- [ ] Rubric added to `buildJobAnalysisPrompt` in `src/lib/ai/prompts.ts`.
+- [ ] Manually test 5 real job listings with 3 different CV profiles (junior, mid, staff). Confirm score distribution is sensible.
+- [ ] Document the rubric in `CLAUDE.md` under "AI SDK Usage" so future prompt edits respect it.
+
+**Files to touch**
+- `src/lib/ai/prompts.ts`
+- `CLAUDE.md`
+
+---
+
+### [T0-3] Kill the hallucinated salary estimate
+
+**Tier:** 0 · **Complexity:** S (cut) / L (replace with real data) · **Depends on:** —
+
+**Why**
+The current prompt asks Claude to invent a salary range for every listing. Users anchor real negotiations on this number. If we're 20% low on a staff-level offer, we just cost the user $30k+. Generating fake numbers in high-stakes decisions is a product liability, not a feature.
+
+**What — pick one of two approaches:**
+
+**Option A (recommended for now — ship this week)**
+Replace the generated number with actionable guidance. When the listing doesn't include salary, return a structured object pointing the user at sources:
+```
+salary_estimate: {
+  shown_in_listing: false,
+  guidance: "This listing hides comp. For similar roles, check Levels.fyi (tech) or Glassdoor (broader). Ask the recruiter for the band before the first interview — legally required in NYC, CA, WA, CO.",
+  negotiation_tip: "...based on candidate's matched skills..."
+}
+```
+When the listing does include salary, extract and pass through — don't estimate.
+
+**Option B (do later)**
+Integrate real data: Levels.fyi scrape for top-500 tech companies, PayScale/Glassdoor API for broader. Gated behind a "market data" toggle. Track as a separate follow-up issue.
+
+**Acceptance criteria**
+- [ ] Prompt updated to stop generating synthetic salary ranges when listing has no comp info.
+- [ ] When listing contains salary, extract and pass through verbatim.
+- [ ] UI shows either the real range (from listing) or the guidance message — never a generated number.
+- [ ] Zod schema for `salary_estimate` updated to reflect the new shape.
+- [ ] Migration note: existing `job_analyses.salary_estimate` rows remain valid (additive change).
+
+**Files to touch**
+- `src/lib/ai/prompts.ts`
+- `src/lib/validation/schemas.ts`
+- `src/types/index.ts`
+- `src/components/jobs/*` (wherever salary is rendered)
+
+---
+
+### [T0-4] Migrate interview feedback from regex parsing to structured output
+
+**Tier:** 0 · **Complexity:** M · **Depends on:** —
+
+**Why**
+The current feedback flow asks Claude to write markdown ending with `[SCORE: XX]`, then parses that with a regex. Your codebase already uses `generateObject` + Zod everywhere else. The markdown-with-magic-suffix approach is fragile (one malformed output and the score is `null`) and inconsistent with the rest of the codebase.
+
+**What**
+- Switch the feedback endpoint from `streamText` to `streamObject` (or keep streaming and parse delta-wise into a structured schema).
+- Return `{ feedback, strengths[], improvements[], score }` as typed output.
+- UI renders the structured parts — no more markdown-through-CSS.
+
+**Schema to add in `src/lib/validation/schemas.ts`:**
+```ts
+export const InterviewFeedbackSchema = z.object({
+  feedback: z.string().min(20),
+  strengths: z.array(z.string()).min(1).max(5),
+  improvements: z.array(z.string()).min(1).max(5),
+  score: z.number().int().min(0).max(100),
+  star_coverage: z.object({   // only for behavioral
+    situation: z.boolean(),
+    task: z.boolean(),
+    action: z.boolean(),
+    result: z.boolean(),
+  }).optional(),
+});
+```
+
+**Acceptance criteria**
+- [ ] `buildInterviewFeedbackSystem` rewritten to produce structured output, not markdown.
+- [ ] API route uses `streamObject` or equivalent.
+- [ ] Client renders strengths/improvements as proper lists, not markdown-parsed bullets.
+- [ ] STAR coverage shown as 4 checkboxes for behavioral questions only.
+- [ ] Remove any `[SCORE: XX]` regex from the codebase.
+
+**Files to touch**
+- `src/lib/ai/prompts.ts`
+- `src/lib/validation/schemas.ts`
+- `src/app/api/interview/*`
+- `src/components/interview/*`
+
+---
+
+### [T0-5] Show confidence tiers on AI outputs
+
+**Tier:** 0 · **Complexity:** M · **Depends on:** T0-2, T0-3
+
+**Why**
+Every AI number in the app currently looks equally confident. A fit score that's based on 7 explicitly matched skills should look different from one that's based on inferring seniority from job titles. Users can't act on the AI because they can't tell when to trust it.
+
+**What**
+- Every AI output is annotated internally with how it was derived: `explicit`, `inferred`, `speculative`.
+- UI renders a small confidence indicator next to each number (a dot, a tier label, or a tooltip).
+- Starts with Job Analyzer (highest-stakes numbers) and expands outward.
+
+**Schema additions (for `job_analyses`):**
+```sql
+ALTER TABLE job_analyses
+  ADD COLUMN IF NOT EXISTS fit_score_basis TEXT,
+    -- 'explicit' | 'inferred' | 'speculative'
+  ADD COLUMN IF NOT EXISTS fit_score_rationale TEXT;
+    -- 1-2 sentence explanation of what the score is based on
+```
+
+**Prompt change**
+Extend the output schema to require `fit_score_basis` + `fit_score_rationale`. Example rationale: *"Matched 7/9 listed skills explicitly. Seniority inferred from years of experience, not stated titles. Salary band unknown — listing hides it."*
+
+**Acceptance criteria**
+- [ ] Schema migration adds the two new columns.
+- [ ] Job analysis output includes basis + rationale.
+- [ ] UI shows a tier badge next to fit score (e.g. Grounded / Inferred / Speculative).
+- [ ] Hovering the badge shows the rationale.
+- [ ] Pattern documented in `CLAUDE.md` for re-use in other features (interview scoring, career roadmap).
+
+**Files to touch**
+- `schema.sql`
+- `src/lib/ai/prompts.ts`
+- `src/lib/validation/schemas.ts`
+- `src/types/index.ts`
+- `src/components/jobs/*`
+- `src/components/ui/ConfidenceBadge.tsx` (new)
+- `CLAUDE.md`
+
+---
+
+## Tier 1 — Core Loop
+
+Five issues that make the app actually useful between signup and first offer. Do these after Tier 0.
+
+---
+
+### [T1-1] Per-job CV tailoring
+
+**Tier:** 1 · **Complexity:** L · **Depends on:** T0-2, T0-5
+
+**Why**
+"Single active CV" is not the real problem — most users only have one CV. The real gap is that the same CV goes to every application. You already have the parsed CV and the parsed job. The feature is: reshape one into a tailored version for the other.
+
+**What**
+On any job analysis, add a "Tailor CV for this role" button. AI returns:
+- Reordered experience section (relevant roles first).
+- Rewritten bullet points emphasizing matched skills, downplaying irrelevant ones.
+- Reordered skills list (matched skills up top).
+- Optional: one rewritten summary/headline targeted at the role.
+
+Output is editable in a rich editor, then exports PDF + DOCX.
+
+**New table:**
+```sql
+CREATE TABLE IF NOT EXISTS tailored_cvs (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  cv_id            UUID        NOT NULL REFERENCES cvs(id) ON DELETE CASCADE,
+  job_analysis_id  UUID        NOT NULL REFERENCES job_analyses(id) ON DELETE CASCADE,
+  tailored_data    JSONB       NOT NULL,    -- mirrors ParsedCvData shape
+  user_edits       JSONB,                    -- user overrides (persist them!)
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+**Acceptance criteria**
+- [ ] `POST /api/cv/tailor` accepts `job_analysis_id`, returns tailored JSON.
+- [ ] UI shows side-by-side view: original vs tailored, with a diff toggle.
+- [ ] User edits persist to `user_edits` column (unlike the current cover letter flow — don't repeat that mistake).
+- [ ] PDF export via `window.print` with a clean print stylesheet.
+- [ ] DOCX export via the `docx` skill — use the existing npm `docx` package or the skill SKILL.md.
+- [ ] Rate-limited (2/hr per user, per-route).
+- [ ] Linked tailored CV shows up on the associated application row.
+
+**Files to touch**
+- `schema.sql`
+- `src/types/index.ts`
+- `src/lib/ai/prompts.ts` (new prompt: `buildCvTailorPrompt`)
+- `src/lib/validation/schemas.ts`
+- `src/app/api/cv/tailor/route.ts` (new)
+- `src/components/cv/TailoredCvView.tsx` (new)
+- `src/lib/rateLimit.ts`
+
+---
+
+### [T1-2] Adaptive interview mode with follow-up questions
+
+**Tier:** 1 · **Complexity:** L · **Depends on:** T0-4
+
+**Why**
+The current interview is a flat list of 10 questions. Real interviewers probe vague answers. If a candidate says "I led the migration", a real interviewer asks "led how? what did you actually own?" — and that's where weak answers get exposed. A flat list doesn't practice that.
+
+**What**
+Convert the interview flow into a turn-based conversation:
+1. Claude generates a first question (existing logic).
+2. User answers.
+3. Claude decides: follow-up (if answer is vague/shallow) OR move to the next question.
+4. Repeat until 8–10 main questions have been asked (follow-ups don't count toward the total).
+5. Final feedback synthesizes across all answers including follow-ups.
+
+**Prompt strategy**
+- Use `generateObject` for the interviewer's next move: `{ action: 'follow_up' | 'next_question' | 'end', text: string, reasoning: string }`.
+- Store full transcript in `interview_sessions.questions` (schema already JSONB).
+- Add a `parent_question_id` to link follow-ups to their parent.
+
+**Acceptance criteria**
+- [ ] `POST /api/interview/next-turn` takes session + latest answer, returns next move.
+- [ ] UI shows a chat-like interface, not a form.
+- [ ] Follow-ups visually nested under their parent question.
+- [ ] Session ends after 8–10 parent questions (configurable per session).
+- [ ] Final overall score accounts for follow-up performance.
+- [ ] `questions` JSONB shape extended to support `parent_id`, `is_follow_up`.
+- [ ] Rate limit: counted as one request per session turn (not per question).
+
+**Files to touch**
+- `src/lib/ai/prompts.ts` (new: `buildInterviewNextTurnPrompt`)
+- `src/lib/validation/schemas.ts`
+- `src/app/api/interview/*`
+- `src/components/interview/*`
+- `src/types/index.ts`
+
+---
+
+### [T1-3] Application follow-up reminders
+
+**Tier:** 1 · **Complexity:** M · **Depends on:** —
+
+**Why**
+The tracker is a filing cabinet, not a coach. Users open it when they add an application and never again. Adding time-based reminders turns it into a recurring surface — and "polite follow-up" is a concrete, valuable action the app can help with.
+
+**What**
+- For every application in `applied` status with `applied_at` ≥ 10 days ago and status still `applied`, show a "Follow up?" prompt.
+- One-click generates a polite follow-up email/LinkedIn message (Claude-drafted, editable, copyable — do not send from the app).
+- Track whether the user sent it (new boolean column).
+
+**Schema:**
+```sql
+ALTER TABLE applications
+  ADD COLUMN IF NOT EXISTS follow_up_sent_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS follow_up_draft TEXT;
+```
+
+**Acceptance criteria**
+- [ ] Dashboard widget: "3 applications need a follow-up" when applicable.
+- [ ] One-click generate follow-up draft (reuses `cover-letter/generate` rate limit bucket? → separate bucket, 10/hr, these are short).
+- [ ] Copy-to-clipboard + "I sent it" confirmation.
+- [ ] Don't re-prompt after user marks as sent.
+- [ ] Don't prompt for applications moved past `applied` status.
+
+**Files to touch**
+- `schema.sql`
+- `src/app/api/applications/follow-up/route.ts` (new)
+- `src/components/dashboard/FollowUpWidget.tsx` (new)
+- `src/lib/ai/prompts.ts`
+- `src/lib/rateLimit.ts`
+
+---
+
+### [T1-4] Company context panel on Job Analyzer
+
+**Tier:** 1 · **Complexity:** M · **Depends on:** —
+
+**Why**
+The analyzer currently evaluates the job text in a vacuum. Same listing at "Stripe" and "unknown seed-stage startup" gets similar treatment. Company health (layoffs, growth, Glassdoor, funding stage) is a huge signal the app ignores.
+
+**What**
+When the user provides a company name, fetch and display:
+- Glassdoor rating (if available, via scrape or third-party API).
+- Recent news headlines (via web search — limit 3 most recent, last 90 days).
+- Layoff mentions (layoffs.fyi check or news filter).
+- Funding stage (Crunchbase lite or inferred from news).
+
+Display as a compact side panel next to the fit score. If no company provided, panel is hidden.
+
+**Acceptance criteria**
+- [ ] New `/api/jobs/company-context` endpoint, takes `company` string, returns structured data.
+- [ ] Cached server-side per (company, date) to avoid re-fetching the same company 10 times per user.
+- [ ] Graceful degradation: if scrape fails, panel shows "Couldn't fetch context — [link to search]".
+- [ ] Clear disclaimer: "Context is auto-fetched, may be inaccurate."
+- [ ] Rate limited at IP level to prevent abuse of the scrape endpoint.
+
+**Files to touch**
+- `src/app/api/jobs/company-context/route.ts` (new)
+- `src/components/jobs/CompanyContextPanel.tsx` (new)
+- `src/lib/cache.ts` (new, or inline)
+
+**Note**
+Decide data source first. Options: (a) web search via your existing tooling, (b) Clearbit API (paid), (c) Glassdoor scrape (brittle). Recommend (a) + (b) combo.
+
+---
+
+### [T1-5] First-session activation — CV upload on signup, not in empty dashboard
+
+**Tier:** 1 · **Complexity:** M · **Depends on:** —
+
+**Why**
+Current flow: user signs up → confirms email → lands in empty dashboard → has to discover CV upload in the sidebar. The highest-intent moment in the whole funnel is the 60 seconds after email confirmation, and we waste it with an empty state. Every feature in the app depends on a parsed CV, yet nothing pushes the user toward that action.
+
+**What**
+- After email confirmation callback, redirect to `/onboarding/cv` instead of `/dashboard`.
+- `/onboarding/cv` is a single-purpose page: big drop-zone, one sentence of copy, skip button (small, below the fold).
+- After successful parse, redirect to `/onboarding/first-analysis` — pre-filled tip: "Paste a job listing you're interested in. We'll tell you if it's worth your time."
+- After first job analysis, unlock the full dashboard.
+- Show a one-time welcome toast on dashboard: "You're set up. Try [Interview Coach] or [Career Ladder] next."
+
+**Acceptance criteria**
+- [ ] `src/app/auth/callback/route.ts` redirects new users to `/onboarding/cv`, returning users to `/dashboard`.
+- [ ] `profiles` table gets `onboarding_completed_at TIMESTAMPTZ` column.
+- [ ] Skip is possible but the dashboard shows a persistent banner until CV is uploaded.
+- [ ] Onboarding pages are minimal — no sidebar, no distractions.
+- [ ] First-time dashboard shows suggested next action, not 6 widgets.
+
+**Files to touch**
+- `schema.sql`
+- `src/app/auth/callback/route.ts`
+- `src/app/(auth)/onboarding/cv/page.tsx` (new)
+- `src/app/(auth)/onboarding/first-analysis/page.tsx` (new)
+- `src/app/(dashboard)/dashboard/page.tsx`
+
+---
+
+## Tier 2 — The Moat
+
+Five issues. These use data only your app has (parsed CV × job analysis × interview × outcome), so they're structurally hard for Huntr/Teal/Simplify to copy. Do these after Tier 1.
+
+---
+
+### [T2-1] Outcome-conditioned fit scores (few-shot from user's own history)
+
+**Tier:** 2 · **Complexity:** L · **Depends on:** T0-1, T0-5, T1-5
+
+**Why**
+Right now every fit score is generated fresh, with no memory of whether prior predictions were right. Once you have 5+ outcomes per user, you can feed the user's own history back into the prompt as calibration examples. This turns the AI from a guesser into a learner — and it's the thing no competitor without your parsed-CV-plus-outcome dataset can replicate.
+
+**What**
+When generating a new job analysis:
+1. Query the user's last 10 applications with captured outcomes.
+2. Pair each with its fit score at application time.
+3. Inject as few-shot examples into the prompt.
+4. The model is explicitly instructed: "For this user, a fit score of X historically led to outcome Y. Recalibrate this new score accordingly."
+
+Also add a background job that, monthly, computes per-user calibration drift ("your fit scores over-predict by an average of 12 points") and surfaces it in Analytics.
+
+**Acceptance criteria**
+- [ ] Job analysis prompt accepts optional `user_history` context.
+- [ ] Context built from last 10 `applications` joined to `job_analyses` with non-null `outcome_stage_reached`.
+- [ ] Prompt length capped — if history is too long, keep the 5 most recent rejections + 5 most recent positive outcomes.
+- [ ] New analytics widget: "Your AI calibration" showing over/under-prediction trend.
+- [ ] Graceful fallback: if user has <3 outcomes, run without conditioning.
+
+**Files to touch**
+- `src/lib/ai/prompts.ts`
+- `src/app/api/jobs/analyze/route.ts`
+- `src/components/analytics/*`
+
+---
+
+### [T2-2] Interview performance trends by question type
+
+**Tier:** 2 · **Complexity:** M · **Depends on:** T0-4
+
+**Why**
+You store every interview score by question type (`behavioral` / `technical` / `role-specific`) but never surface the trend. Users can't tell if they're improving at behaviorals and plateauing on technical — or vice versa. This is almost-free insight sitting in your JSONB.
+
+**What**
+- Add a "Progress" view inside Interview Coach: per-question-type score average over last N sessions.
+- Trend lines (behavioral improving, technical flat, etc).
+- Recommend focus: "Your technical scores haven't moved in 6 sessions. Try a targeted session."
+- On session completion, surface: "You scored 82 on behaviorals (up from 65 six weeks ago)."
+
+**Acceptance criteria**
+- [ ] Dedicated query view: all sessions grouped by question type, sorted by `created_at`.
+- [ ] Small line chart per question type (use existing `recharts` if available, or SVG).
+- [ ] Copy generated server-side (not AI — just templated insights based on slope).
+- [ ] Accessible from Interview Coach landing and from Analytics.
+
+**Files to touch**
+- `src/app/(dashboard)/interview/progress/page.tsx` (new)
+- `src/components/interview/ProgressView.tsx` (new)
+- `src/components/analytics/*`
+
+---
+
+### [T2-3] Rejection post-mortem
+
+**Tier:** 2 · **Complexity:** M · **Depends on:** T0-1, T0-5
+
+**Why**
+When a user marks an application `rejected`, we have everything needed for a learning moment — fit score at time of application, matched vs missing skills, stage reached — and we do nothing with it. A 30-second post-mortem after rejection closes the most valuable loop in the app: failure → insight → updated plan.
+
+**What**
+When status changes to `rejected` and the outcome modal is completed:
+- Trigger a lightweight AI analysis: given this fit score, these missing skills, and this stage reached, what's the most likely gap?
+- Show result as a short card: "Most likely gap: [specific missing skill]. Users rejected at [stage] with similar profiles often [specific action]."
+- Offer: "Add this to your Career Ladder?" button → updates roadmap with this skill flagged as priority.
+
+**Acceptance criteria**
+- [ ] New `POST /api/applications/post-mortem` endpoint.
+- [ ] Triggered automatically on rejection status + outcome capture.
+- [ ] Output structured: `{ likely_gap, similar_profiles_action, roadmap_update_suggestion }`.
+- [ ] User can dismiss or accept the roadmap update.
+- [ ] Aggregated across all a user's rejections in Analytics: "Your top 3 rejection patterns."
+
+**Files to touch**
+- `src/app/api/applications/post-mortem/route.ts` (new)
+- `src/lib/ai/prompts.ts`
+- `src/components/applications/RejectionPostMortem.tsx` (new)
+- `src/components/analytics/*`
+
+---
+
+### [T2-4] Rebuild Career Ladder as a living plan with CV-evolution tracking
+
+**Tier:** 2 · **Complexity:** L · **Depends on:** T0-1
+
+**Why**
+The current Career Ladder is a one-shot document the user sees once and forgets. The parsed CV already changes over time (new upload = new skills, new experience). Linking these turns a dead PDF into a living plan: "You added Kubernetes since your last upload. You're now 40% through the Staff IC path."
+
+**What**
+Replace the current three-paths generator with a persistent plan:
+- User picks one path at generation time (IC / Management / Specialized) — not three simultaneously.
+- Each missing skill and recommended project becomes a tracked item with a status (`not_started` / `in_progress` / `done`).
+- On every new CV upload, diff skills against the previous version. Auto-mark newly-added skills as `done` in the roadmap.
+- Show a "Next step" card on the dashboard: the single highest-priority unchecked item.
+- Add resource links (course / book / tutorial) per skill — Claude-suggested initially, editable.
+
+**Schema:**
+```sql
+CREATE TABLE IF NOT EXISTS roadmap_items (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  roadmap_id   UUID        NOT NULL REFERENCES career_roadmaps(id) ON DELETE CASCADE,
+  item_type    TEXT        NOT NULL,  -- 'skill' | 'project' | 'experience'
+  title        TEXT        NOT NULL,
+  description  TEXT,
+  resources    JSONB       DEFAULT '[]',  -- [{ title, url, type }]
+  status       TEXT        NOT NULL DEFAULT 'not_started',
+  completed_at TIMESTAMPTZ,
+  auto_completed_by_cv_id UUID REFERENCES cvs(id) ON DELETE SET NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+**Acceptance criteria**
+- [ ] User generates one path (not three) per roadmap.
+- [ ] Roadmap items persist and can be individually marked done.
+- [ ] New CV upload triggers skill diff → auto-complete any roadmap items where the missing skill now appears.
+- [ ] Dashboard surfaces "Next step" card.
+- [ ] Resource links per skill (start with AI-generated, allow user to edit/replace).
+- [ ] Historical view: "6 weeks ago vs today" diff.
+
+**Files to touch**
+- `schema.sql`
+- `src/lib/ai/prompts.ts`
+- `src/app/api/career/*`
+- `src/components/career/*`
+- `src/components/dashboard/NextStepWidget.tsx` (new)
+- `src/components/cv/*` (wire up the diff on upload)
+
+---
+
+### [T2-5] Aggregate insights: "users like you" benchmarking
+
+**Tier:** 2 · **Complexity:** L · **Depends on:** T0-1, T2-1
+
+**Why**
+Once 100+ users have outcomes, you can compare an individual's predicted vs actual outcomes to the cohort. This is the feature the audit calls out ("users with your profile got hired for role X") and it's the single strongest retention hook you can build — because it's the thing users physically cannot get anywhere else.
+
+**What**
+- Define cohorts by (seniority, role family, years of experience bracket).
+- For any user with ≥3 applications tracked, show anonymized aggregate: "Users in your cohort (staff-level backend, 6–9 yrs) have a 14% response rate on fit scores ≥ 75."
+- Compare user's own rates to the cohort.
+- Only activate once cohort has ≥20 users (privacy + statistical validity).
+
+**Acceptance criteria**
+- [ ] New materialized view or scheduled aggregate in the DB computing cohort stats weekly.
+- [ ] Cohort assignment logic in code (not AI).
+- [ ] UI shows benchmarks only when user's cohort has ≥20 members.
+- [ ] All displayed stats are aggregate-only; no per-user data leaks.
+- [ ] Privacy notice: users can opt out of contributing to aggregates (default: opted-in, disclosed at signup).
+
+**Files to touch**
+- `schema.sql` (materialized view or aggregate table)
+- `src/app/api/analytics/cohort/route.ts` (new)
+- `src/components/analytics/*`
+- Privacy copy in signup + settings
+
+---
+
+## Design / UX
+
+Four issues. These are independent of the tiers and can be shipped in parallel with Tier 0/1.
+
+---
+
+### [D-1] Landing page rebuild — lead with the trigger, not the feature grid
+
+**Complexity:** M · **Depends on:** —
+
+**Why**
+Current landing is a seven-feature grid with equal weight. This sells to people already sold. Real users arrive at a career tool because of a specific trigger (got a rejection, saw a listing, got laid off, bombed an interview). The page should answer: "in the 60 seconds you're here, what should you try?"
+
+**What**
+- **New hero:** "Paste a job listing. Know in 30 seconds if it's worth your time." With an inline demo (text input + mock analysis) that works without login.
+- **Below hero:** 3 concrete before/after scenarios ("I saw a listing at 10pm — should I apply?", "I got rejected — what went wrong?", "I have an interview Tuesday"). Each one links to a feature.
+- **Demoted:** feature grid moves below the scenarios, not the first thing visible.
+- **Social proof slot:** empty for now, but scaffolded ("N CVs analyzed this week" etc — wire up later).
+- **Remove inline styles.** The whole page is full of `style={{ ... }}` mixed with Tailwind. Pick one. Recommend: convert all to Tailwind + CSS vars already defined in `globals.css`.
+
+**Acceptance criteria**
+- [ ] Hero has a working inline demo (Job Analyzer running unauthenticated — rate-limited to 1 request per IP per day).
+- [ ] Three scenario cards replace the feature grid as the primary below-hero element.
+- [ ] All `style={{ backgroundColor: ... }}` inline rules replaced with Tailwind classes or CSS variables.
+- [ ] Mobile layout works (current design is desktop-first).
+- [ ] Copy does not list all 7 features; it names 2–3 at most.
+
+**Files to touch**
+- `src/app/page.tsx`
+- `src/app/globals.css`
+- `src/app/api/jobs/demo-analyze/route.ts` (new — unauth, heavily rate-limited)
+
+---
+
+### [D-2] Auth pages — OAuth, magic link, cleaner flow
+
+**Complexity:** M · **Depends on:** —
+
+**Why**
+The signup form asks for 4 fields (display name, email, password, confirm password) with password rules. This is 2026 — OAuth with Google/GitHub eliminates 90% of that friction and matches what technical users expect. Email/password should be the fallback, not the default.
+
+**What**
+- **Primary:** Google + GitHub OAuth buttons above everything else.
+- **Secondary:** Magic link (passwordless email) as the second option.
+- **Tertiary:** Email + password, collapsed behind "or use a password".
+- Display name becomes optional (pull from OAuth provider if available; default to email prefix).
+- Remove "Confirm password" — this is a 2009 pattern; use a password-strength meter instead.
+- "Forgot password" link on login (currently missing).
+
+**Acceptance criteria**
+- [ ] Google OAuth configured in Supabase + implemented on login/signup.
+- [ ] GitHub OAuth configured in Supabase + implemented.
+- [ ] Magic link flow works end-to-end (including email confirmation redirect).
+- [ ] Password fallback preserved but demoted visually.
+- [ ] `displayName` no longer required — optional field, defaults handled server-side.
+- [ ] "Forgot password" link + reset flow implemented.
+- [ ] Error messages are still generic (no "email not found" — preserve current security stance).
+
+**Files to touch**
+- `src/app/(auth)/signup/page.tsx`
+- `src/app/(auth)/login/page.tsx`
+- `src/app/(auth)/forgot-password/page.tsx` (new)
+- `src/app/auth/callback/route.ts`
+- Supabase dashboard: OAuth providers + SMTP config
+
+---
+
+### [D-3] Sidebar IA — promote Job Analyzer, demote Cover Letter
+
+**Complexity:** S · **Depends on:** —
+
+**Why**
+Current sidebar gives equal weight to all seven features. Job Analyzer is the hero / front-door. Cover Letter is commodity LLM output and arguably the lowest-leverage feature in the app. The sidebar is reinforcing the wrong hierarchy.
+
+**What**
+Reorganize sidebar into primary and secondary groups:
+
+**Primary (top, always visible):**
+- Dashboard
+- Job Analyzer
+- Applications
+- Interview Coach
+
+**Secondary (grouped under "Tools" or collapsed):**
+- CV Hub (still accessible directly from onboarding banner when CV missing)
+- Career Ladder
+- Cover Letter
+- Analytics
+
+Cover Letter generation should also be **embedded inline inside the Job Analyzer flow** — after a job is analyzed, a small "Draft cover letter" button appears. No longer a top-level destination.
+
+**Acceptance criteria**
+- [ ] Sidebar restructured per above.
+- [ ] Cover Letter appears as an action inside Job Analyzer, not as a nav item (remove from primary nav).
+- [ ] Secondary group collapses on narrow screens.
+- [ ] Existing routes continue to work (don't break old bookmarks).
+
+**Files to touch**
+- `src/components/layout/Sidebar.tsx`
+- `src/components/jobs/*` (add inline Draft Cover Letter action)
+
+---
+
+### [D-4] Rebuild Analytics as a prescriptive dashboard — or fold into Dashboard
+
+**Complexity:** M · **Depends on:** T0-1, T2-1
+
+**Why**
+Current Analytics is descriptive — counts, averages, bars. It's also the only file with hardcoded colors (`bg-[#111827]`) bypassing the theme system. Users don't come back for descriptive stats. They come back for prescriptive insight: what should I do next?
+
+**What — two valid approaches, pick one:**
+
+**Option A (recommended): rebuild as prescriptive insights page.**
+Replace counts with statements:
+- "Your fit scores drop below 60 for roles listing Go. Either learn Go (add to roadmap) or filter these out."
+- "Your behavioral interview score climbed from 65 → 82 in 6 weeks. Strong improvement."
+- "You average 9 days between applying and interview. That's 40% faster than last month."
+- "Your AI calibration: fit scores have over-predicted by 12 points over last 10 outcomes."
+
+Each insight is a templated server-side calculation, not AI (keeps cost low, keeps output deterministic).
+
+**Option B: fold the good parts (funnel, interview history) into the Dashboard. Remove Analytics as a separate page.**
+
+**Acceptance criteria**
+- [ ] All hardcoded colors replaced with CSS variables (`var(--card-bg)` etc).
+- [ ] Either: (A) replace `AnalyticsClient.tsx` with a prescriptive insights component, or (B) move key widgets into the dashboard and delete the page.
+- [ ] Every number shown has a "so what" — either an insight line or it's removed.
+- [ ] No AI calls on page load — all insights are DB-backed computations.
+
+**Files to touch**
+- `src/components/analytics/AnalyticsClient.tsx`
+- `src/app/(dashboard)/analytics/page.tsx`
+- Possibly `src/components/dashboard/*` (if Option B)
+
+---
+
+## Suggested ordering for the first sprint
+
+Week 1–2 (Tier 0):
+1. T0-1 (outcomes — unblocks Tier 2)
+2. T0-2 (fit score rubric — quick win)
+3. T0-3 (kill salary hallucination — liability fix)
+4. T0-4 (structured interview feedback — code quality)
+5. T0-5 (confidence tiers — UX)
+
+Week 3–4 (Tier 1, pick 2):
+- T1-1 (per-job CV tailoring) + T1-5 (activation flow) — these two together reshape the product.
+
+Parallel (design, anytime):
+- D-1, D-2, D-3
+
+Tier 2 starts month 2.
+
+---
+
+*Generated by Claude Opus 4.7 from the CareerPilot audit conversation, April 2026.*

--- a/schema.sql
+++ b/schema.sql
@@ -67,15 +67,21 @@ CREATE TABLE IF NOT EXISTS job_analyses (
   company               TEXT,
   job_raw_text          TEXT        NOT NULL,
   fit_score             INTEGER     CHECK (fit_score >= 0 AND fit_score <= 100),
+  fit_score_basis       TEXT        CHECK (fit_score_basis IN ('explicit', 'inferred', 'speculative')),
+  fit_score_rationale   TEXT,
   recommendation        TEXT        CHECK (recommendation IN ('apply', 'maybe', 'skip')),
   recommendation_reason TEXT,
   matched_skills        TEXT[]      NOT NULL DEFAULT '{}',
   missing_skills        TEXT[]      NOT NULL DEFAULT '{}',
   cv_suggestions        TEXT[]      NOT NULL DEFAULT '{}',
   salary_estimate       JSONB,
-  -- JSONB shape: { currency, low, mid, high, factors[], negotiation_tip }
+  -- JSONB shape: { shown_in_listing, currency?, low?, mid?, high?, guidance?, negotiation_tip }
   created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+-- Idempotent migrations for existing databases
+ALTER TABLE job_analyses ADD COLUMN IF NOT EXISTS fit_score_basis     TEXT CHECK (fit_score_basis IN ('explicit', 'inferred', 'speculative'));
+ALTER TABLE job_analyses ADD COLUMN IF NOT EXISTS fit_score_rationale TEXT;
 
 -- -----------------------------------------------------------------------------
 -- interview_sessions
@@ -135,9 +141,20 @@ CREATE TABLE IF NOT EXISTS applications (
   status           application_status NOT NULL DEFAULT 'saved',
   applied_at       TIMESTAMPTZ,
   notes            TEXT,
+  -- Outcome tracking (populated via modal when status transitions to interviewing/offered/rejected)
+  outcome_stage_reached        TEXT,       -- 'no_response'|'recruiter_screen'|'phone_screen'|'technical'|'onsite'|'offer'
+  outcome_reason               TEXT,       -- free-text, user-provided
+  outcome_fit_score_at_apply   INTEGER,    -- snapshot of job_analyses.fit_score when applied_at was first set
+  outcome_captured_at          TIMESTAMPTZ,
   created_at       TIMESTAMPTZ        NOT NULL DEFAULT NOW(),
   updated_at       TIMESTAMPTZ        NOT NULL DEFAULT NOW()
 );
+
+-- Idempotent migrations for existing databases
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS outcome_stage_reached      TEXT;
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS outcome_reason              TEXT;
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS outcome_fit_score_at_apply  INTEGER;
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS outcome_captured_at         TIMESTAMPTZ;
 
 -- -----------------------------------------------------------------------------
 -- rate_limit_events

--- a/src/app/(dashboard)/jobs/[id]/page.tsx
+++ b/src/app/(dashboard)/jobs/[id]/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { JobAnalysis, SalaryEstimate } from "@/types";
 import { FitScoreArc } from "@/components/jobs/FitScoreArc";
 import { TrackApplicationButton } from "@/components/jobs/TrackApplicationButton";
+import { ConfidenceBadge } from "@/components/ui/ConfidenceBadge";
 import Link from "next/link";
 import {
   ArrowLeft,
@@ -15,14 +16,15 @@ import {
   FileEdit,
   DollarSign,
   TrendingUp,
+  Info,
 } from "lucide-react";
 
 interface PageProps {
   params: Promise<{ id: string }>;
 }
 
-// ── Salary range bar ──────────────────────────────────────────────────────────
-function SalaryRangeBar({ salary }: { salary: SalaryEstimate }) {
+// ── Salary section helpers ────────────────────────────────────────────────────
+function SalaryRangeBar({ salary }: { salary: Extract<SalaryEstimate, { shown_in_listing: true }> }) {
   const range = salary.high - salary.low;
   const midPct = range > 0 ? ((salary.mid - salary.low) / range) * 100 : 50;
 
@@ -34,18 +36,15 @@ function SalaryRangeBar({ salary }: { salary: SalaryEstimate }) {
 
   return (
     <div className="space-y-4">
-      {/* Range row */}
       <div className="flex items-center gap-3">
         <span className="text-sm font-semibold text-gray-400 w-16 text-right shrink-0">
           {salary.currency} {fmt(salary.low)}
         </span>
         <div className="relative flex-1 h-3 bg-[#1E3A5F]/60 rounded-full">
-          {/* Fill to mid */}
           <div
             className="absolute left-0 top-0 h-full bg-blue-600/60 rounded-full"
             style={{ width: `${midPct}%` }}
           />
-          {/* Mid marker */}
           <div
             className="absolute top-1/2 w-4 h-4 bg-blue-400 rounded-full border-2 border-[#0A0F1C] shadow"
             style={{ left: `${midPct}%`, transform: "translate(-50%, -50%)" }}
@@ -55,13 +54,35 @@ function SalaryRangeBar({ salary }: { salary: SalaryEstimate }) {
           {salary.currency} {fmt(salary.high)}
         </span>
       </div>
-      {/* Mid label */}
       <p className="text-center text-xs text-gray-500">
-        Mid-range estimate:{" "}
+        Mid-range (from listing):{" "}
         <span className="text-white font-semibold">
           {salary.currency} {fmt(salary.mid)}
         </span>
       </p>
+    </div>
+  );
+}
+
+function SalarySection({ salary }: { salary: SalaryEstimate }) {
+  return (
+    <div className="space-y-6">
+      {salary.shown_in_listing ? (
+        <SalaryRangeBar salary={salary} />
+      ) : (
+        <div className="flex items-start gap-3 bg-[#0A0F1C] border border-[#1E3A5F] rounded-lg p-4">
+          <Info className="w-4 h-4 text-blue-400 shrink-0 mt-0.5" />
+          <p className="text-sm text-gray-300 leading-relaxed">{salary.guidance}</p>
+        </div>
+      )}
+
+      <div className="flex items-start gap-3 bg-[#0A0F1C] border border-[#1E3A5F] rounded-lg p-4">
+        <TrendingUp className="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
+        <p className="text-sm text-gray-300 leading-relaxed">
+          <span className="text-emerald-400 font-semibold">Negotiation tip: </span>
+          {salary.negotiation_tip}
+        </p>
+      </div>
     </div>
   );
 }
@@ -102,7 +123,12 @@ export default async function JobAnalysisResultPage({ params }: PageProps) {
       {/* Header card */}
       <div className="bg-[#111827] border border-[#1E3A5F] rounded-2xl p-6 sm:p-8 flex flex-col sm:flex-row gap-8 items-start sm:items-center relative overflow-hidden">
         <div className="absolute top-0 right-0 w-64 h-64 bg-blue-600/5 rounded-full blur-3xl pointer-events-none transform translate-x-1/2 -translate-y-1/2" />
-        <FitScoreArc score={analysis.fit_score ?? 0} />
+        <div className="flex flex-col items-center gap-2">
+          <FitScoreArc score={analysis.fit_score ?? 0} />
+          {analysis.fit_score_basis && (
+            <ConfidenceBadge basis={analysis.fit_score_basis} rationale={analysis.fit_score_rationale} />
+          )}
+        </div>
         <div className="flex-1 space-y-4 relative z-10 w-full">
           <div>
             <h1 className="text-2xl sm:text-3xl font-extrabold text-white" style={{ fontFamily: "var(--font-heading)" }}>
@@ -184,40 +210,16 @@ export default async function JobAnalysisResultPage({ params }: PageProps) {
         )}
       </div>
 
-      {/* Salary Estimate */}
+      {/* Salary */}
       {analysis.salary_estimate && (
         <div className="bg-[#111827] border border-[#1E3A5F] rounded-xl p-6 space-y-6">
           <div className="flex items-center gap-2 text-white pb-3 border-b border-[#1E3A5F]">
             <DollarSign className="w-5 h-5 text-emerald-500" />
-            <h3 className="text-lg font-bold" style={{ fontFamily: "var(--font-heading)" }}>Salary Estimate</h3>
-            <span className="ml-auto text-xs text-gray-600 font-normal">
-              Verify with Glassdoor or Levels.fyi
-            </span>
+            <h3 className="text-lg font-bold" style={{ fontFamily: "var(--font-heading)" }}>
+              {analysis.salary_estimate.shown_in_listing ? "Salary (from listing)" : "Salary"}
+            </h3>
           </div>
-
-          <SalaryRangeBar salary={analysis.salary_estimate} />
-
-          {/* Factors */}
-          {analysis.salary_estimate.factors?.length > 0 && (
-            <div className="flex flex-wrap gap-2">
-              {analysis.salary_estimate.factors.map((f, i) => (
-                <span key={i} className="px-2.5 py-1 bg-emerald-500/10 text-emerald-400 text-xs font-medium rounded-md border border-emerald-500/20">
-                  {f}
-                </span>
-              ))}
-            </div>
-          )}
-
-          {/* Negotiation tip */}
-          {analysis.salary_estimate.negotiation_tip && (
-            <div className="flex items-start gap-3 bg-[#0A0F1C] border border-[#1E3A5F] rounded-lg p-4">
-              <TrendingUp className="w-4 h-4 text-emerald-400 shrink-0 mt-0.5" />
-              <p className="text-sm text-gray-300 leading-relaxed">
-                <span className="text-emerald-400 font-semibold">Negotiation tip: </span>
-                {analysis.salary_estimate.negotiation_tip}
-              </p>
-            </div>
-          )}
+          <SalarySection salary={analysis.salary_estimate} />
         </div>
       )}
 

--- a/src/app/api/applications/[id]/route.ts
+++ b/src/app/api/applications/[id]/route.ts
@@ -33,6 +33,28 @@ export async function PATCH(
       return errorResponse("No valid fields to update", 400);
     }
 
+    // When transitioning to 'applied' for the first time, snapshot the linked fit_score
+    if (patch.status === "applied" && patch.applied_at) {
+      const { data: existing } = await supabase
+        .from("applications")
+        .select("job_analysis_id, applied_at, outcome_fit_score_at_apply")
+        .eq("id", id)
+        .eq("user_id", user.id)
+        .single();
+
+      if (existing && !existing.applied_at && !existing.outcome_fit_score_at_apply && existing.job_analysis_id) {
+        const { data: analysis } = await supabase
+          .from("job_analyses")
+          .select("fit_score")
+          .eq("id", existing.job_analysis_id)
+          .single();
+
+        if (analysis?.fit_score != null) {
+          (patch as Record<string, unknown>).outcome_fit_score_at_apply = analysis.fit_score;
+        }
+      }
+    }
+
     const { data: updated, error: patchError } = await supabase
       .from("applications")
       .update(patch)

--- a/src/app/api/interview/feedback/route.ts
+++ b/src/app/api/interview/feedback/route.ts
@@ -1,9 +1,9 @@
 import { createClient } from "@/lib/supabase/server";
 import { checkRateLimit, consumeRateLimit } from "@/lib/rateLimit";
-import { streamText } from "ai";
+import { streamObject } from "ai";
 import { anthropic } from "@ai-sdk/anthropic";
 import { ParsedCvData } from "@/types";
-import { interviewFeedbackSchema } from "@/lib/validation/schemas";
+import { interviewFeedbackSchema, InterviewFeedbackOutputSchema } from "@/lib/validation/schemas";
 import { buildInterviewFeedbackSystem } from "@/lib/ai/prompts";
 import { logger } from "@/lib/logger";
 import { errorResponse, rateLimitResponse } from "@/lib/apiResponse";
@@ -56,8 +56,9 @@ export async function POST(req: Request) {
 
     const systemMessage = buildInterviewFeedbackSystem(parsedCv, question, type, jobTitle, company);
 
-    const result = streamText({
+    const result = streamObject({
       model: anthropic("claude-haiku-4-5"),
+      schema: InterviewFeedbackOutputSchema,
       messages: [
         { role: "system", content: systemMessage },
         { role: "user", content: prompt },

--- a/src/app/api/jobs/analyze/route.ts
+++ b/src/app/api/jobs/analyze/route.ts
@@ -62,20 +62,29 @@ export async function POST(req: Request) {
       model: anthropic("claude-haiku-4-5"),
       schema: z.object({
         fit_score: z.number().int(),
+        fit_score_basis: z.enum(["explicit", "inferred", "speculative"]),
+        fit_score_rationale: z.string(),
         recommendation: z.enum(["apply", "maybe", "skip"]),
         recommendation_reason: z.string(),
         matched_skills: z.array(z.string()),
         missing_skills: z.array(z.string()),
         cv_suggestions: z.array(z.string()),
         salary_estimate: z
-          .object({
-            currency: z.string(),
-            low: z.number(),
-            mid: z.number(),
-            high: z.number(),
-            factors: z.array(z.string()),
-            negotiation_tip: z.string(),
-          })
+          .discriminatedUnion("shown_in_listing", [
+            z.object({
+              shown_in_listing: z.literal(true),
+              currency: z.string(),
+              low: z.number(),
+              mid: z.number(),
+              high: z.number(),
+              negotiation_tip: z.string(),
+            }),
+            z.object({
+              shown_in_listing: z.literal(false),
+              guidance: z.string(),
+              negotiation_tip: z.string(),
+            }),
+          ])
           .nullable()
           .optional(),
       }),
@@ -91,6 +100,8 @@ export async function POST(req: Request) {
         company: company ?? null,
         job_raw_text: jobRawText,
         fit_score: analysis.fit_score,
+        fit_score_basis: analysis.fit_score_basis,
+        fit_score_rationale: analysis.fit_score_rationale,
         recommendation: analysis.recommendation,
         recommendation_reason: analysis.recommendation_reason,
         matched_skills: analysis.matched_skills,

--- a/src/components/applications/ApplicationsClient.tsx
+++ b/src/components/applications/ApplicationsClient.tsx
@@ -6,9 +6,10 @@ import { format } from "date-fns";
 import Link from "next/link";
 import {
   ClipboardList, Plus, X, ExternalLink, Briefcase,
-  Building2, Calendar, FileEdit, Check, Loader2, Trash2, Link2
+  Building2, Calendar, FileEdit, Check, Loader2, Trash2
 } from "lucide-react";
-import { Application, ApplicationStatus } from "@/types";
+import { Application, ApplicationStatus, OutcomeStage } from "@/types";
+import { OutcomeModal } from "./OutcomeModal";
 
 const STATUSES: { value: ApplicationStatus; label: string; color: string; bg: string; border: string }[] = [
   { value: "saved",        label: "Saved",        color: "text-gray-400",   bg: "bg-gray-500/10",   border: "border-gray-500/20" },
@@ -41,6 +42,12 @@ export function ApplicationsClient({ initialApplications }: Props) {
     status: "saving" | "saved" | "error";
   } | null>(null);
 
+  // Outcome modal: holds the app + target status awaiting modal confirmation
+  const [pendingOutcome, setPendingOutcome] = useState<{
+    app: Application;
+    status: ApplicationStatus;
+  } | null>(null);
+
   // Add form state
   const [addTitle, setAddTitle] = useState("");
   const [addCompany, setAddCompany] = useState("");
@@ -65,11 +72,63 @@ export function ApplicationsClient({ initialApplications }: Props) {
     return res.json() as Promise<Application>;
   }, []);
 
-  const handleStatusChange = async (app: Application, status: ApplicationStatus) => {
-    const updated = await patchApp(app.id, { status }).catch(() => null);
-    if (!updated) { toast.error("Failed to update status"); return; }
-    setApps((prev) => prev.map((a) => (a.id === app.id ? { ...a, status } : a)));
-    if (selectedApp?.id === app.id) setSelectedApp((p) => p && { ...p, status });
+  const OUTCOME_STATUSES: ApplicationStatus[] = ["interviewing", "offered", "rejected"];
+
+  const applyStatusPatch = useCallback(
+    async (
+      app: Application,
+      status: ApplicationStatus,
+      outcomeFields?: {
+        outcome_stage_reached?: OutcomeStage | null;
+        outcome_reason?: string | null;
+        outcome_captured_at?: string | null;
+      }
+    ) => {
+      const patch: Record<string, unknown> = { status };
+      // Auto-set applied_at when transitioning to 'applied' for the first time
+      if (status === "applied" && !app.applied_at) {
+        patch.applied_at = new Date().toISOString();
+      }
+      if (outcomeFields) Object.assign(patch, outcomeFields);
+
+      const updated = await patchApp(app.id, patch).catch(() => null);
+      if (!updated) { toast.error("Failed to update status"); return; }
+      setApps((prev) => prev.map((a) => (a.id === app.id ? { ...a, ...updated } : a)));
+      if (selectedApp?.id === app.id) setSelectedApp((p) => p && { ...p, ...updated });
+    },
+    [patchApp, selectedApp]
+  );
+
+  const handleStatusChange = (app: Application, status: ApplicationStatus) => {
+    if (OUTCOME_STATUSES.includes(status)) {
+      setPendingOutcome({ app, status });
+    } else {
+      applyStatusPatch(app, status);
+    }
+  };
+
+  const handleOutcomeSubmit = async ({
+    stage,
+    reason,
+  }: {
+    stage: OutcomeStage | null;
+    reason: string;
+  }) => {
+    if (!pendingOutcome) return;
+    const { app, status } = pendingOutcome;
+    setPendingOutcome(null);
+    await applyStatusPatch(app, status, {
+      outcome_stage_reached: stage,
+      outcome_reason: reason || null,
+      outcome_captured_at: new Date().toISOString(),
+    });
+  };
+
+  const handleOutcomeSkip = () => {
+    if (!pendingOutcome) return;
+    const { app, status } = pendingOutcome;
+    setPendingOutcome(null);
+    applyStatusPatch(app, status);
   };
 
   const handleNotesChange = (app: Application, notes: string) => {
@@ -145,6 +204,13 @@ export function ApplicationsClient({ initialApplications }: Props) {
   // ── Render ────────────────────────────────────────────────────────────────
   return (
     <div className="max-w-6xl mx-auto space-y-8 pb-24 animate-fade-in-up">
+      {pendingOutcome && (
+        <OutcomeModal
+          status={pendingOutcome.status}
+          onSubmit={handleOutcomeSubmit}
+          onSkip={handleOutcomeSkip}
+        />
+      )}
 
       {/* Header */}
       <div className="flex items-center justify-between gap-4 flex-wrap">

--- a/src/components/applications/OutcomeModal.tsx
+++ b/src/components/applications/OutcomeModal.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { X, ChevronDown } from "lucide-react";
+import { ApplicationStatus, OutcomeStage } from "@/types";
+import { OUTCOME_STAGES } from "@/lib/validation/schemas";
+
+const STAGE_LABELS: Record<OutcomeStage, string> = {
+  no_response: "No response",
+  recruiter_screen: "Recruiter screen",
+  phone_screen: "Phone / video screen",
+  technical: "Technical interview",
+  onsite: "Onsite / final round",
+  offer: "Reached offer stage",
+};
+
+interface OutcomeModalProps {
+  status: ApplicationStatus;
+  onSubmit: (outcome: { stage: OutcomeStage | null; reason: string }) => void;
+  onSkip: () => void;
+}
+
+export function OutcomeModal({ status, onSubmit, onSkip }: OutcomeModalProps) {
+  const [stage, setStage] = useState<OutcomeStage | "">("");
+  const [reason, setReason] = useState("");
+
+  const title =
+    status === "interviewing"
+      ? "How did it go so far?"
+      : status === "offered"
+      ? "Congrats on the offer! Any notes?"
+      : "What happened?";
+
+  const stagePlaceholder =
+    status === "interviewing"
+      ? "What stage are you at?"
+      : "What was the furthest stage you reached?";
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ stage: stage || null, reason: reason.trim() });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <div className="w-full max-w-md bg-[#111827] border border-[#1E3A5F] rounded-2xl shadow-2xl animate-fade-in-up">
+        <div className="flex items-center justify-between p-5 border-b border-[#1E3A5F]">
+          <h2 className="text-base font-bold text-white">{title}</h2>
+          <button onClick={onSkip} className="text-gray-500 hover:text-white transition-colors">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-5 space-y-4">
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-gray-400 uppercase tracking-wider">
+              Stage reached
+            </label>
+            <div className="relative">
+              <select
+                value={stage}
+                onChange={(e) => setStage(e.target.value as OutcomeStage | "")}
+                className="w-full appearance-none bg-[#0A0F1C] border border-[#1E3A5F] rounded-lg px-3 py-2.5 text-white text-sm focus:outline-none focus:border-blue-500 transition-colors pr-8"
+              >
+                <option value="">{stagePlaceholder}</option>
+                {OUTCOME_STAGES.map((s) => (
+                  <option key={s} value={s}>
+                    {STAGE_LABELS[s]}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none" />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-gray-400 uppercase tracking-wider">
+              Anything notable? <span className="normal-case font-normal">(optional)</span>
+            </label>
+            <textarea
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={3}
+              placeholder="Recruiter feedback, rejection reason, what went well…"
+              className="w-full bg-[#0A0F1C] border border-[#1E3A5F] rounded-lg px-3 py-2.5 text-white text-sm placeholder:text-gray-600 focus:outline-none focus:border-blue-500 transition-colors resize-none"
+            />
+          </div>
+
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={onSkip}
+              className="flex-1 px-4 py-2.5 bg-[#0A0F1C] border border-[#1E3A5F] text-gray-400 hover:text-white rounded-lg text-sm font-medium transition-colors"
+            >
+              Skip
+            </button>
+            <button
+              type="submit"
+              className="flex-1 px-4 py-2.5 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-medium transition-colors"
+            >
+              Save
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/interview/ActiveSession.tsx
+++ b/src/components/interview/ActiveSession.tsx
@@ -2,16 +2,19 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useCompletion } from "@ai-sdk/react";
+import { experimental_useObject as useObject } from "@ai-sdk/react";
 import { toast } from "sonner";
-import { 
-  Building2, 
-  MessageSquare, 
-  SendHorizontal, 
+import {
+  Building2,
+  MessageSquare,
+  SendHorizontal,
   ArrowRight,
   Loader2,
-  CheckCircle2
+  CheckCircle2,
+  ThumbsUp,
+  ArrowUpCircle,
 } from "lucide-react";
+import { InterviewFeedbackOutputSchema } from "@/lib/validation/schemas";
 
 interface InterviewQuestion {
   id: string;
@@ -21,6 +24,9 @@ interface InterviewQuestion {
   user_answer?: string;
   feedback?: string;
   score?: number;
+  strengths?: string[];
+  improvements?: string[];
+  star_coverage?: { situation: boolean; task: boolean; action: boolean; result: boolean };
 }
 
 interface ActiveSessionProps {
@@ -32,168 +38,139 @@ interface ActiveSessionProps {
 
 export function ActiveSession({ sessionId, questions: initialQs, jobTitle, company }: ActiveSessionProps) {
   const router = useRouter();
-  
-  // Create a copy of the questions locally so we can augment them with answers/feedback
+
   const [questions, setQuestions] = useState<InterviewQuestion[]>(initialQs);
   const [currentIndex, setCurrentIndex] = useState(0);
-  
+  const [answer, setAnswer] = useState("");
   const [isSaving, setIsSaving] = useState(false);
 
-  // The auto-scroll ref for streaming feedback
   const feedbackEndRef = useRef<HTMLDivElement>(null);
-
   const currentQ = questions[currentIndex];
-  // Determine if this question has been answered and received feedback already 
-  const isQuestionAnswered = !!currentQ.feedback;
+  const isAnswered = !!currentQ.feedback;
 
-  // ── AI Stream ─────────────────────────────────────────────────────────────
-  const { completion, input, setInput, handleInputChange, handleSubmit, isLoading } = useCompletion({
+  const { object, submit, isLoading } = useObject({
     api: "/api/interview/feedback",
-    body: {
-      question: currentQ?.question_text,
-      type: currentQ?.type,
-      jobTitle,
-      company
-    },
-    onFinish: async (prompt: string, aiResponse: string) => {
-      // Stream is fully done. Let's extract numeric score if it exists like [SCORE: 75]
-      let score: number | undefined;
-      let cleanFeedback = aiResponse;
-      
-      const scoreMatch = aiResponse.match(/\[SCORE:\s*(\d+)\]/i);
-      if (scoreMatch) {
-        score = parseInt(scoreMatch[1], 10);
-        // Remove the score tag from the final visible text
-        cleanFeedback = aiResponse.replace(scoreMatch[0], "").trim();
-      }
+    schema: InterviewFeedbackOutputSchema,
+    onFinish: async ({ object: result }: { object: typeof InterviewFeedbackOutputSchema._type | undefined }) => {
+      if (!result) return;
 
-      // 1. Update local state copy so UI shows the final pinned version
-      const qsClone = [...questions];
-      qsClone[currentIndex] = {
-        ...qsClone[currentIndex],
-        user_answer: prompt, // store their submitted text
-        feedback: cleanFeedback,
-        score,
+      const updatedQ: InterviewQuestion = {
+        ...currentQ,
+        user_answer: answer,
+        feedback: result.feedback,
+        score: result.score,
+        strengths: result.strengths,
+        improvements: result.improvements,
+        star_coverage: result.star_coverage,
       };
-      setQuestions(qsClone);
 
-      // 2. Persist to DB directly into the JSONB array via PATCH endpoint
+      setQuestions((prev) => prev.map((q, i) => (i === currentIndex ? updatedQ : q)));
+
       setIsSaving(true);
       try {
-        const patchRes = await fetch(`/api/interview/${sessionId}`, {
+        const res = await fetch(`/api/interview/${sessionId}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             questionIndex: currentIndex,
-            answer: prompt,
-            feedback: cleanFeedback,
-            score,
+            answer,
+            feedback: result.feedback,
+            score: result.score,
+            star_coverage: result.star_coverage,
           }),
         });
-        if (!patchRes.ok) throw new Error("Failed to save answer");
-      } catch (err) {
-        console.error(err);
-        toast.error("Answer saved locally but failed to sync to database.");
+        if (!res.ok) throw new Error();
+      } catch {
+        toast.error("Answer saved locally but failed to sync.");
       } finally {
         setIsSaving(false);
       }
     },
-    onError: (err: Error) => {
-      toast.error(err.message || "Failed to generate feedback.");
-    }
+    onError: () => toast.error("Failed to generate feedback."),
   });
 
-  // When changing questions, reset the input to any previously saved answer or blank
   useEffect(() => {
     const q = questions[currentIndex];
-    setInput(q.user_answer || "");
-  }, [currentIndex, questions, setInput]);
+    setAnswer(q.user_answer || "");
+  }, [currentIndex, questions]);
 
-  // Auto scroll feedback while streaming
   useEffect(() => {
     feedbackEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [completion]);
+  }, [object]);
 
-  // ── Handlers ──────────────────────────────────────────────────────────────
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!answer.trim() || isAnswered) return;
+    submit({
+      prompt: answer,
+      question: currentQ.question_text,
+      type: currentQ.type,
+      jobTitle,
+      company,
+    });
+  };
+
   const onSkip = async () => {
-    if (isSaving || isQuestionAnswered) return;
+    if (isSaving || isAnswered) return;
     setIsSaving(true);
-    const skipFeedback = "Question skipped.";
-    const skipAnswer = "Skipped";
-
-    const qsClone = [...questions];
-    qsClone[currentIndex] = {
-      ...qsClone[currentIndex],
-      user_answer: skipAnswer,
-      feedback: skipFeedback,
+    const skippedQ: InterviewQuestion = {
+      ...currentQ,
+      user_answer: "Skipped",
+      feedback: "Question skipped.",
       score: 0,
     };
-    setQuestions(qsClone);
-
+    setQuestions((prev) => prev.map((q, i) => (i === currentIndex ? skippedQ : q)));
     try {
-      const patchRes = await fetch(`/api/interview/${sessionId}`, {
+      const res = await fetch(`/api/interview/${sessionId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          questionIndex: currentIndex,
-          answer: skipAnswer,
-          feedback: skipFeedback,
-          score: 0,
-        }),
+        body: JSON.stringify({ questionIndex: currentIndex, answer: "Skipped", feedback: "Question skipped.", score: 0 }),
       });
-      if (!patchRes.ok) throw new Error("Failed to save skipped answer");
-    } catch (err) {
-      console.error(err);
-      toast.error("Failed to sync skip to database.");
+      if (!res.ok) throw new Error();
+    } catch {
+      toast.error("Failed to sync skip.");
     } finally {
       setIsSaving(false);
     }
   };
 
-  const onNextQuestion = () => {
-    if (currentIndex < questions.length - 1) {
-      setCurrentIndex((prev) => prev + 1);
-    }
-  };
-
   const onSeeResults = async () => {
     setIsSaving(true);
-    const answeredQs = questions.filter(q => q.score !== undefined);
-    
-    if (answeredQs.length > 0) {
-      const sum = answeredQs.reduce((acc, q) => acc + (q.score || 0), 0);
-      const avg = Math.round(sum / answeredQs.length);
-      
+    const answered = questions.filter((q) => q.score !== undefined);
+    if (answered.length > 0) {
+      const avg = Math.round(answered.reduce((s, q) => s + (q.score ?? 0), 0) / answered.length);
       try {
         await fetch(`/api/interview/${sessionId}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ overall_score: avg }),
         });
-      } catch (err) {
-        console.error("Failed to save overall score", err);
+      } catch {
+        console.error("Failed to save overall score");
       }
     }
-    
     router.push(`/interview/${sessionId}/results`);
   };
 
-  const onSubmitAnswerWrapper = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!input.trim() || isQuestionAnswered) return;
-    
-    // Trigger the actual Vercel AI useCompletion POST request
-    handleSubmit(e);
-  };
+  // When saved, use the stored question fields. When streaming, use the partial object.
+  const displayFeedback = isAnswered
+    ? {
+        feedback: currentQ.feedback,
+        strengths: currentQ.strengths,
+        improvements: currentQ.improvements,
+        score: currentQ.score,
+        star_coverage: currentQ.star_coverage,
+      }
+    : object;
 
   if (!currentQ) return null;
 
   return (
     <div className="space-y-6 animate-fade-in-up">
-      {/* ── Header ──────────────────────────────────────────────────────── */}
+      {/* Header */}
       <div className="flex flex-col sm:flex-row items-baseline justify-between gap-4 pb-4 border-b border-[#1E3A5F]">
         <div>
-          <h1 className="text-xl font-bold text-white flex items-center gap-2" style={{ fontFamily: "var(--font-heading)" }}>
+          <h1 className="text-xl font-bold text-white" style={{ fontFamily: "var(--font-heading)" }}>
             {jobTitle}
           </h1>
           {company && (
@@ -202,123 +179,167 @@ export function ActiveSession({ sessionId, questions: initialQs, jobTitle, compa
             </span>
           )}
         </div>
-        
-        {/* Progress Tracker */}
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium text-gray-400 uppercase tracking-wider">
             Question {currentIndex + 1} of {questions.length}
           </span>
           <div className="w-24 h-2 bg-[#1E3A5F] rounded-full overflow-hidden shrink-0">
-            <div 
-              className="h-full bg-blue-500 rounded-full transition-all" 
+            <div
+              className="h-full bg-blue-500 rounded-full transition-all"
               style={{ width: `${((currentIndex + 1) / questions.length) * 100}%` }}
             />
           </div>
         </div>
       </div>
 
-      {/* ── Main Question Area ──────────────────────────────────────────── */}
-      <div className="bg-[#111827] border border-[#1E3A5F] rounded-2xl p-6 sm:p-8 space-y-8 relative overflow-hidden">
-        
-        {/* Type Badge */}
-        <div className="mb-4">
-          <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold uppercase tracking-wider border ${
-            currentQ.type === 'behavioral' ? 'bg-purple-500/10 text-purple-400 border-purple-500/20' :
-            currentQ.type === 'technical' ? 'bg-blue-500/10 text-blue-400 border-blue-500/20' :
-            'bg-amber-500/10 text-amber-400 border-amber-500/20'
-          }`}>
+      {/* Question card */}
+      <div className="bg-[#111827] border border-[#1E3A5F] rounded-2xl p-6 sm:p-8 space-y-8">
+        <div>
+          <span
+            className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold uppercase tracking-wider border ${
+              currentQ.type === "behavioral"
+                ? "bg-purple-500/10 text-purple-400 border-purple-500/20"
+                : currentQ.type === "technical"
+                ? "bg-blue-500/10 text-blue-400 border-blue-500/20"
+                : "bg-amber-500/10 text-amber-400 border-amber-500/20"
+            }`}
+          >
             {currentQ.type} Question
           </span>
         </div>
 
-        {/* The Question Text */}
         <p className="text-xl sm:text-2xl font-medium text-white leading-relaxed">
           &ldquo;{currentQ.question_text}&rdquo;
         </p>
 
-        {/* User Answer Form */}
-        <form onSubmit={onSubmitAnswerWrapper} className="space-y-4 pt-4 border-t border-[#1E3A5F]/50">
-          <label className="block text-sm font-medium text-gray-300">
-            Your Answer
-          </label>
+        {/* Answer form */}
+        <form onSubmit={onSubmit} className="space-y-4 pt-4 border-t border-[#1E3A5F]/50">
+          <label className="block text-sm font-medium text-gray-300">Your Answer</label>
           <textarea
-            value={input}
-            onChange={handleInputChange} // bound directly to useCompletion
-            disabled={isLoading || isQuestionAnswered || isSaving}
+            value={answer}
+            onChange={(e) => setAnswer(e.target.value)}
+            disabled={isLoading || isAnswered || isSaving}
             placeholder="Type your answer here exactly as you would speak it..."
             className="w-full h-40 bg-[#0A0F1C] border border-[#1E3A5F] rounded-xl p-4 text-white text-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500/50 resize-none disabled:opacity-60 transition-colors"
           />
-
-          {!isQuestionAnswered && !isLoading && (
+          {!isAnswered && !isLoading && (
             <div className="flex justify-end gap-3">
               <button
                 type="button"
                 onClick={onSkip}
                 disabled={isSaving}
-                className="flex items-center justify-center gap-2 px-6 py-2.5 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-gray-300 font-medium rounded-lg transition-colors text-sm border border-gray-700"
+                className="flex items-center gap-2 px-6 py-2.5 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 text-gray-300 font-medium rounded-lg transition-colors text-sm border border-gray-700"
               >
                 Skip
               </button>
               <button
                 type="submit"
-                disabled={!input.trim() || isSaving}
-                className="flex items-center justify-center gap-2 px-6 py-2.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors text-sm"
+                disabled={!answer.trim() || isSaving}
+                className="flex items-center gap-2 px-6 py-2.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white font-medium rounded-lg transition-colors text-sm"
               >
-                Submit Answer
-                <SendHorizontal className="w-4 h-4" />
+                Submit Answer <SendHorizontal className="w-4 h-4" />
               </button>
             </div>
           )}
         </form>
 
-        {/* ── Feedback Stream / Result Area ─────────────────────────────── */}
-        {(isLoading || completion || currentQ.feedback) && (
-          <div className="bg-blue-900/10 border border-blue-500/20 rounded-xl p-6 mt-6 animate-fade-in-up">
-            <h3 className="flex items-center gap-2 text-blue-400 font-semibold mb-3">
+        {/* Feedback area */}
+        {(isLoading || displayFeedback) && (
+          <div className="bg-blue-900/10 border border-blue-500/20 rounded-xl p-6 space-y-5 animate-fade-in-up">
+            <div className="flex items-center gap-2 text-blue-400 font-semibold">
               <MessageSquare className="w-5 h-5" />
               AI Interviewer Feedback
-            </h3>
-            <div className="text-sm text-gray-300 leading-relaxed whitespace-pre-wrap">
-              {/* Either show final saved feedback, or the live streaming text */}
-              {currentQ.feedback || completion}
-              
-              {isLoading && (
-                <span className="inline-block w-1.5 h-4 ml-1 bg-blue-400 animate-pulse translate-y-0.5" />
-              )}
+              {isLoading && <Loader2 className="w-4 h-4 animate-spin ml-auto" />}
             </div>
-            
-            {/* Show badge if the backend assigned a score */}
-            {currentQ.score !== undefined && (
-              <div className="mt-4 inline-flex items-center gap-1.5 px-3 py-1 bg-green-500/10 text-green-400 text-xs font-bold rounded border border-green-500/20">
-                <CheckCircle2 className="w-4 h-4" />
-                Score: {currentQ.score}/100
+
+            {displayFeedback?.feedback && (
+              <p className="text-sm text-gray-300 leading-relaxed">{displayFeedback.feedback}</p>
+            )}
+
+            {displayFeedback?.strengths && displayFeedback.strengths.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-xs font-semibold text-green-400 uppercase tracking-wider flex items-center gap-1.5">
+                  <ThumbsUp className="w-3.5 h-3.5" /> Strengths
+                </p>
+                <ul className="space-y-1.5">
+                  {displayFeedback.strengths.filter((s): s is string => !!s).map((s, i) => (
+                    <li key={i} className="flex gap-2 text-sm text-gray-300">
+                      <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0 mt-0.5" />
+                      {s}
+                    </li>
+                  ))}
+                </ul>
               </div>
             )}
-            
+
+            {displayFeedback?.improvements && displayFeedback.improvements.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-xs font-semibold text-amber-400 uppercase tracking-wider flex items-center gap-1.5">
+                  <ArrowUpCircle className="w-3.5 h-3.5" /> Improvements
+                </p>
+                <ul className="space-y-1.5">
+                  {displayFeedback.improvements.filter((s): s is string => !!s).map((s, i) => (
+                    <li key={i} className="flex gap-2 text-sm text-gray-300">
+                      <span className="w-4 h-4 shrink-0 mt-0.5 text-amber-500 font-bold text-xs flex items-center justify-center">
+                        {i + 1}
+                      </span>
+                      {s}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* STAR coverage — behavioral only */}
+            {displayFeedback?.star_coverage && (
+              <div className="space-y-2">
+                <p className="text-xs font-semibold text-purple-400 uppercase tracking-wider">STAR Coverage</p>
+                <div className="grid grid-cols-2 gap-2">
+                  {(["situation", "task", "action", "result"] as const).map((key) => (
+                    <div
+                      key={key}
+                      className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border text-xs font-medium ${
+                        displayFeedback.star_coverage?.[key]
+                          ? "bg-green-500/10 border-green-500/20 text-green-400"
+                          : "bg-red-500/10 border-red-500/20 text-red-400"
+                      }`}
+                    >
+                      <CheckCircle2 className="w-3.5 h-3.5 shrink-0" />
+                      {key.charAt(0).toUpperCase() + key.slice(1)}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {displayFeedback?.score !== undefined && (
+              <div className="inline-flex items-center gap-1.5 px-3 py-1 bg-green-500/10 text-green-400 text-xs font-bold rounded border border-green-500/20">
+                <CheckCircle2 className="w-4 h-4" />
+                Score: {displayFeedback.score}/100
+              </div>
+            )}
+
             <div ref={feedbackEndRef} />
           </div>
         )}
-
       </div>
 
-      {/* ── Navigation Actions (Next / Results) ─────────────────────────── */}
-      {isQuestionAnswered && !isLoading && !isSaving && (
+      {/* Navigation */}
+      {isAnswered && !isLoading && !isSaving && (
         <div className="flex justify-end mt-8 animate-fade-in-up">
           {currentIndex < questions.length - 1 ? (
             <button
-              onClick={onNextQuestion}
+              onClick={() => setCurrentIndex((p) => p + 1)}
               className="flex items-center gap-2 px-6 py-3 bg-gray-800 hover:bg-gray-700 text-white font-medium rounded-lg transition-colors border border-gray-700"
             >
-              Next Question
-              <ArrowRight className="w-4 h-4" />
+              Next Question <ArrowRight className="w-4 h-4" />
             </button>
           ) : (
             <button
               onClick={onSeeResults}
               className="flex items-center gap-2 px-8 py-3 bg-green-600 hover:bg-green-500 text-white font-bold rounded-lg transition-colors shadow-lg shadow-green-900/20"
             >
-              Finish & See Overall Results
-              <ArrowRight className="w-4 h-4" />
+              Finish & See Overall Results <ArrowRight className="w-4 h-4" />
             </button>
           )}
         </div>

--- a/src/components/ui/ConfidenceBadge.tsx
+++ b/src/components/ui/ConfidenceBadge.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { FitScoreBasis } from "@/types";
+
+const CONFIG: Record<FitScoreBasis, { label: string; dot: string; tooltip: string }> = {
+  explicit: {
+    label: "Grounded",
+    dot: "bg-green-400",
+    tooltip: "Score based on explicitly matched requirements.",
+  },
+  inferred: {
+    label: "Inferred",
+    dot: "bg-yellow-400",
+    tooltip: "Some requirements or seniority were inferred from context.",
+  },
+  speculative: {
+    label: "Speculative",
+    dot: "bg-orange-400",
+    tooltip: "Significant ambiguity in the listing or profile — treat with caution.",
+  },
+};
+
+interface ConfidenceBadgeProps {
+  basis: FitScoreBasis;
+  rationale?: string | null;
+}
+
+export function ConfidenceBadge({ basis, rationale }: ConfidenceBadgeProps) {
+  const [open, setOpen] = useState(false);
+  const cfg = CONFIG[basis];
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-white/10 bg-white/5 text-xs font-medium text-gray-400 hover:text-white transition-colors"
+      >
+        <span className={`w-2 h-2 rounded-full ${cfg.dot}`} />
+        {cfg.label}
+      </button>
+
+      {open && (
+        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 z-50 pointer-events-none">
+          <div className="bg-[#0A0F1C] border border-[#1E3A5F] rounded-lg p-3 shadow-xl text-xs text-gray-300 leading-relaxed">
+            <p className="font-semibold text-white mb-1">{cfg.label} score</p>
+            <p>{rationale || cfg.tooltip}</p>
+          </div>
+          <div className="w-2 h-2 bg-[#0A0F1C] border-r border-b border-[#1E3A5F] rotate-45 mx-auto -mt-1" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -33,18 +33,34 @@ ${cv.experience.map((e) => `- ${e.title} at ${e.company} (${e.duration}): ${e.su
 
 ---
 
+Use this fit_score rubric strictly. Pick the band the candidate fits, then adjust ±5 within it.
+
+  90–100  Meets every stated requirement + most preferred. Seniority match. Direct domain experience.
+  75–89   Meets all hard requirements. Missing 1–2 preferred. Seniority match or one level off.
+  60–74   Meets most hard requirements. Missing 1 critical hard requirement OR seniority off by one level.
+  40–59   Plausible stretch. Missing 2+ hard requirements or mismatched seniority by 2 levels.
+  20–39   Significant gaps. Would likely fail a resume screen.
+  0–19    Wrong role family or wrong seniority tier entirely.
+
+Before picking a band, list the hard requirements in the listing (as you understand them) and check them off against the candidate's skills and experience. Include this checklist in your internal reasoning but do NOT include it in the output.
+
 Provide:
-1. fit_score (0–100 integer) — genuine match quality, do not inflate
-2. recommendation: 'apply' / 'maybe' / 'skip' — honest assessment
+1. fit_score (0–100 integer) — use the rubric above, do not inflate
+2. fit_score_basis: one of 'explicit' | 'inferred' | 'speculative'
+   - 'explicit': the listing clearly states requirements and the candidate explicitly matches/misses them
+   - 'inferred': seniority, scope, or key requirements had to be inferred from context (titles, company stage, etc.)
+   - 'speculative': significant ambiguity in the listing or the candidate profile — score has lower confidence
+3. fit_score_rationale: 1–2 sentences explaining what the score is based on (e.g. "Matched 7/9 listed skills. Seniority inferred from years of experience — listing doesn't state level.")
+4. recommendation: 'apply' / 'maybe' / 'skip' — honest assessment
 3. recommendation_reason: 1–2 candid sentences
 4. matched_skills: candidate skills that directly match the role
 5. missing_skills: required skills the candidate lacks
 6. cv_suggestions: 3–5 specific, actionable improvements (e.g. "Add Docker to skills — the role lists it as required")
-7. salary_estimate: a realistic salary range for this role in the likely market. Be conservative and honest.
-   - Infer currency and location from the job listing (default to USD if unclear)
-   - low/mid/high should reflect real market rates for the seniority level inferred from the listing
-   - factors: list 3–5 key things influencing the range (e.g. "Remote-friendly", "Series B startup", "Requires 5+ years")
-   - negotiation_tip: 1–2 sentences on the candidate's best leverage points given their matched skills`;
+7. salary_estimate: an object with these exact fields:
+   - shown_in_listing: true if the listing explicitly states a salary range or number, false otherwise
+   - If shown_in_listing is true: extract currency, low, mid (midpoint), and high verbatim from the listing. Do not adjust or estimate — pass through what the listing says.
+   - If shown_in_listing is false: set guidance to a 1–2 sentence message telling the candidate where to research comp for this role (e.g. Levels.fyi for tech, Glassdoor for broader; mention any salary-transparency laws that may apply based on location signals in the listing). Do NOT invent numbers.
+   - negotiation_tip: 1–2 sentences on the candidate's best leverage points given their matched skills (always include regardless of shown_in_listing)`;
 }
 
 // ── Interview Generation ──────────────────────────────────────────────────────
@@ -84,40 +100,23 @@ export function buildInterviewFeedbackSystem(
   jobTitle: string,
   company: string | undefined
 ): string {
-  let evaluationCriteria = `
-You are evaluating the answer based on:
-1. Relevance to the role of ${jobTitle} ${company ? `at ${company}` : ""}
-2. The candidate's background (${cv.current_role}, ${cv.years_of_experience} years exp)`;
-
-  if (type === "behavioral") {
-    evaluationCriteria += `
-3. **STAR Method Framework**: The answer MUST follow the STAR format (Situation, Task, Action, Result).
-Explicitly call out whether they successfully hit all 4 points, or what they missed.`;
-  }
+  const starInstruction =
+    type === "behavioral"
+      ? `\nSTAR COVERAGE: Also return star_coverage with four booleans (situation, task, action, result) indicating whether the candidate's answer addressed each STAR component.`
+      : "";
 
   return `You are a senior hiring manager conducting a mock interview.
-The candidate is answering a **${type}** interview question.
+The candidate is answering a ${type} interview question for the role of ${jobTitle}${company ? ` at ${company}` : ""}.
+
+CANDIDATE BACKGROUND: ${cv.current_role}, ${cv.years_of_experience} years experience.
 
 QUESTION: "${question}"
 
-${evaluationCriteria}
-
-Provide constructive, directly actionable feedback. Be professional but honest. A score of 60 means they need serious improvement; a score of 85+ means an excellent answer.
-
-You MUST format your output EXACTLY like this using Markdown:
-**Feedback:**
-(2-4 sentences evaluating their answer overall)
-
-**Strengths:**
-- (Bullet point 1)
-- (Bullet point 2)
-
-**Improvements:**
-- (Bullet point 1)
-- (Bullet point 2)
-
-[SCORE: XX]
-(Where XX is an integer between 0 and 100 representing their score. EXACTLY this format at the very end).`;
+Evaluate the candidate's answer and return a structured assessment:
+- feedback: 2–4 sentences of direct, constructive overall evaluation. Be honest — a score of 60 means serious improvement needed; 85+ means excellent.
+- strengths: 1–3 specific things the candidate did well.
+- improvements: 1–3 specific, actionable things to improve.
+- score: integer 0–100.${starInstruction}`;
 }
 
 // ── Cover Letter ──────────────────────────────────────────────────────────────

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -28,6 +28,21 @@ export const interviewFeedbackSchema = z.object({
   company: z.string().optional(),
 });
 
+export const InterviewFeedbackOutputSchema = z.object({
+  feedback: z.string().min(20),
+  strengths: z.array(z.string()).min(1).max(5),
+  improvements: z.array(z.string()).min(1).max(5),
+  score: z.number().int().min(0).max(100),
+  star_coverage: z
+    .object({
+      situation: z.boolean(),
+      task: z.boolean(),
+      action: z.boolean(),
+      result: z.boolean(),
+    })
+    .optional(),
+});
+
 // ── Cover Letter ──────────────────────────────────────────────────────────────
 export const generateCoverLetterSchema = z.object({
   jobTitle: z.string().min(1, "jobTitle is required").max(200),
@@ -61,6 +76,15 @@ export const createApplicationSchema = z.object({
   cover_letter_id: z.string().uuid().optional().nullable(),
 });
 
+export const OUTCOME_STAGES = [
+  "no_response",
+  "recruiter_screen",
+  "phone_screen",
+  "technical",
+  "onsite",
+  "offer",
+] as const;
+
 export const patchApplicationSchema = z.object({
   status: z.enum(APPLICATION_STATUSES).optional(),
   notes: z.string().max(5000).optional().nullable(),
@@ -68,4 +92,8 @@ export const patchApplicationSchema = z.object({
   job_url: z.string().url().optional().nullable().or(z.literal("")),
   company: z.string().max(200).optional().nullable(),
   cover_letter_id: z.string().uuid().optional().nullable(),
+  outcome_stage_reached: z.enum(OUTCOME_STAGES).optional().nullable(),
+  outcome_reason: z.string().max(2000).optional().nullable(),
+  outcome_fit_score_at_apply: z.number().int().min(0).max(100).optional().nullable(),
+  outcome_captured_at: z.string().datetime().optional().nullable(),
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,14 +36,22 @@ export interface ParsedCvData {
 }
 
 // ── Job Analysis ──────────────────────────────────────────────────────────────
-export interface SalaryEstimate {
-  currency: string;        // e.g. "GBP", "USD"
-  low: number;             // e.g. 45000
-  mid: number;             // e.g. 60000
-  high: number;            // e.g. 75000
-  factors: string[];       // e.g. ["Remote role", "4 years experience"]
-  negotiation_tip: string;
-}
+export type SalaryEstimate =
+  | {
+      shown_in_listing: true;
+      currency: string;
+      low: number;
+      mid: number;
+      high: number;
+      negotiation_tip: string;
+    }
+  | {
+      shown_in_listing: false;
+      guidance: string;
+      negotiation_tip: string;
+    };
+
+export type FitScoreBasis = 'explicit' | 'inferred' | 'speculative';
 
 export interface JobAnalysis {
   id: string;
@@ -53,6 +61,8 @@ export interface JobAnalysis {
   company: string | null;
   job_raw_text: string;
   fit_score: number | null;
+  fit_score_basis: FitScoreBasis | null;
+  fit_score_rationale: string | null;
   recommendation: 'apply' | 'maybe' | 'skip' | null;
   recommendation_reason: string | null;
   matched_skills: string[];
@@ -115,6 +125,14 @@ export interface CoverLetter {
 // ── Application Tracker ───────────────────────────────────────────────────────
 export type ApplicationStatus = 'saved' | 'applied' | 'interviewing' | 'offered' | 'rejected';
 
+export type OutcomeStage =
+  | "no_response"
+  | "recruiter_screen"
+  | "phone_screen"
+  | "technical"
+  | "onsite"
+  | "offer";
+
 export interface Application {
   id: string;
   user_id: string;
@@ -126,6 +144,10 @@ export interface Application {
   status: ApplicationStatus;
   applied_at: string | null;
   notes: string | null;
+  outcome_stage_reached: OutcomeStage | null;
+  outcome_reason: string | null;
+  outcome_fit_score_at_apply: number | null;
+  outcome_captured_at: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
- T0-1: capture structured outcomes on application status changes
  (stage reached, reason, fit score snapshot); outcome modal shown on
  interviewing/offered/rejected transitions, skippable
- T0-2: replace single-line fit score instruction with a 6-band rubric
  (0–19 through 90–100) anchored to concrete conditions; documented in CLAUDE.md
- T0-3: stop generating synthetic salary estimates; extract range verbatim
  when listing includes comp, return research guidance otherwise
- T0-4: migrate interview feedback from streamText + [SCORE: XX] regex to
  streamObject with typed schema; renders strengths/improvements as lists
  and STAR coverage checkboxes for behavioural questions
- T0-5: add fit_score_basis (explicit/inferred/speculative) and
  fit_score_rationale to job analyses; ConfidenceBadge renders under the
  fit score arc with a tooltip showing the rationale
  
  Closes #49 
  closes #50 
  closes #51 
  Closes #52 
  Closes #53 