### PR TITLE
feat: implement all T1 Tier-1 features (core loop)

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -31,12 +31,16 @@ END $$;
 -- One row per user, auto-created via trigger on signup.
 -- -----------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS profiles (
-  id          UUID        PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
-  full_name   TEXT,
-  avatar_url  TEXT,
-  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  id                    UUID        PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  full_name             TEXT,
+  avatar_url            TEXT,
+  onboarding_completed_at TIMESTAMPTZ,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+-- Idempotent migration for existing databases
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS onboarding_completed_at TIMESTAMPTZ;
 
 -- -----------------------------------------------------------------------------
 -- cvs
@@ -155,6 +159,23 @@ ALTER TABLE applications ADD COLUMN IF NOT EXISTS outcome_stage_reached      TEX
 ALTER TABLE applications ADD COLUMN IF NOT EXISTS outcome_reason              TEXT;
 ALTER TABLE applications ADD COLUMN IF NOT EXISTS outcome_fit_score_at_apply  INTEGER;
 ALTER TABLE applications ADD COLUMN IF NOT EXISTS outcome_captured_at         TIMESTAMPTZ;
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS follow_up_sent_at           TIMESTAMPTZ;
+ALTER TABLE applications ADD COLUMN IF NOT EXISTS follow_up_draft             TEXT;
+
+-- -----------------------------------------------------------------------------
+-- tailored_cvs
+-- AI-tailored CV versions linked to a specific job analysis.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS tailored_cvs (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  cv_id            UUID        NOT NULL REFERENCES cvs(id) ON DELETE CASCADE,
+  job_analysis_id  UUID        NOT NULL REFERENCES job_analyses(id) ON DELETE CASCADE,
+  tailored_data    JSONB       NOT NULL,
+  user_edits       JSONB,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
 
 -- -----------------------------------------------------------------------------
 -- rate_limit_events
@@ -218,6 +239,7 @@ CREATE TRIGGER update_applications_updated_at
 -- 4. ROW LEVEL SECURITY
 -- =============================================================================
 
+ALTER TABLE tailored_cvs       ENABLE ROW LEVEL SECURITY;
 ALTER TABLE profiles           ENABLE ROW LEVEL SECURITY;
 ALTER TABLE cvs                ENABLE ROW LEVEL SECURITY;
 ALTER TABLE job_analyses       ENABLE ROW LEVEL SECURITY;
@@ -226,6 +248,13 @@ ALTER TABLE career_roadmaps    ENABLE ROW LEVEL SECURITY;
 ALTER TABLE cover_letters      ENABLE ROW LEVEL SECURITY;
 ALTER TABLE applications       ENABLE ROW LEVEL SECURITY;
 ALTER TABLE rate_limit_events  ENABLE ROW LEVEL SECURITY;
+
+-- tailored_cvs
+DROP POLICY IF EXISTS "Users can only access their own data" ON tailored_cvs;
+CREATE POLICY "Users can only access their own data"
+  ON tailored_cvs FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
 
 -- profiles
 DROP POLICY IF EXISTS "Users can only access their own data" ON profiles;

--- a/src/app/(auth)/onboarding/cv/page.tsx
+++ b/src/app/(auth)/onboarding/cv/page.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useDropzone } from "react-dropzone";
+import { toast } from "sonner";
+import { UploadCloud, Loader2, CheckCircle2, X, ArrowRight } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import Link from "next/link";
+
+export default function OnboardingCvPage() {
+  const router = useRouter();
+  const supabase = createClient();
+  const [state, setState] = useState<"idle" | "uploading" | "parsing" | "success" | "failed">("idle");
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [currentCvId, setCurrentCvId] = useState<string | null>(null);
+
+  const handleUpload = async (file: File) => {
+    try {
+      setState("uploading");
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user) { router.push("/login"); return; }
+
+      const fileName = `${Date.now()}-${file.name.replace(/[^a-zA-Z0-9.-]/g, "_")}`;
+      const filePath = `${user.id}/${fileName}`;
+
+      const { error: uploadError } = await supabase.storage.from("cvs").upload(filePath, file);
+      if (uploadError) throw new Error(uploadError.message);
+
+      await supabase.from("cvs").update({ is_active: false }).eq("user_id", user.id).eq("is_active", true);
+
+      const { data: inserted, error: insertError } = await supabase
+        .from("cvs")
+        .insert({ user_id: user.id, file_name: file.name, file_path: filePath, is_active: true })
+        .select()
+        .single();
+      if (insertError) throw new Error(insertError.message);
+
+      const cvId = inserted.id;
+      setCurrentCvId(cvId);
+      setState("parsing");
+      setParseError(null);
+
+      // Fire parse
+      fetch("/api/cv/parse", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cvId }),
+      }).catch(() => null);
+
+      // Poll for success
+      const start = Date.now();
+      const poll = async () => {
+        if (Date.now() - start > 120_000) {
+          setState("failed");
+          setParseError("Parsing timed out. Please try again.");
+          return;
+        }
+        const { data } = await supabase.from("cvs").select("parse_status, parse_error").eq("id", cvId).single();
+        if (data?.parse_status === "success") {
+          setState("success");
+          toast.success("CV uploaded! Now let's see how you match your first job.");
+          setTimeout(() => router.push("/onboarding/first-analysis"), 1500);
+        } else if (data?.parse_status === "failed") {
+          setState("failed");
+          setParseError(data.parse_error || "Failed to parse CV.");
+        } else {
+          setTimeout(poll, 5000);
+        }
+      };
+      poll();
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Upload failed");
+      setState("idle");
+    }
+  };
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    accept: {
+      "application/pdf": [".pdf"],
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [".docx"],
+      "application/msword": [".doc"],
+    },
+    maxSize: 5 * 1024 * 1024,
+    onDropRejected: (files) => {
+      const err = files[0]?.errors[0];
+      toast.error(err?.code === "file-too-large" ? "File exceeds 5MB" : "Only PDF, DOCX, DOC accepted");
+    },
+    onDropAccepted: (files) => handleUpload(files[0]),
+    disabled: state !== "idle",
+  });
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6" style={{ background: "var(--bg-base)" }}>
+      <div className="w-full max-w-xl">
+        {/* Logo */}
+        <div className="text-center mb-10">
+          <span className="text-2xl font-extrabold tracking-tight" style={{ fontFamily: "var(--font-heading)", color: "#F1F5F9" }}>
+            Career<span style={{ color: "#2563EB" }}>Pilot</span>
+          </span>
+        </div>
+
+        <div className="bg-[#111827] border border-[#1E3A5F] rounded-2xl p-8 space-y-6">
+          <div className="text-center space-y-2">
+            <h1 className="text-2xl font-extrabold text-white" style={{ fontFamily: "var(--font-heading)" }}>
+              Upload your CV
+            </h1>
+            <p className="text-gray-400 text-sm leading-relaxed">
+              Your CV powers every CareerPilot feature. Upload it once and we&apos;ll match you to jobs instantly.
+            </p>
+          </div>
+
+          <div
+            {...(state === "idle" ? getRootProps() : {})}
+            className={`border-2 border-dashed rounded-xl p-10 flex flex-col items-center justify-center gap-4 text-center transition-all min-h-[220px] ${
+              state === "idle" ? "cursor-pointer" : "cursor-default"
+            } ${
+              isDragActive ? "border-blue-500 bg-blue-500/10" :
+              state === "failed" ? "border-red-500/50 bg-red-500/5" :
+              "border-[#1E3A5F] hover:border-blue-500/50"
+            }`}
+          >
+            <input {...(state === "idle" ? getInputProps() : {})} />
+
+            {state === "idle" && (
+              <>
+                <div className="p-3 bg-blue-500/10 rounded-full">
+                  <UploadCloud className="w-8 h-8 text-blue-500" />
+                </div>
+                <div>
+                  <p className="text-white font-medium">
+                    {isDragActive ? "Drop it here" : "Click or drag your CV here"}
+                  </p>
+                  <p className="text-xs text-gray-500 mt-1">PDF, DOCX, or DOC — max 5MB</p>
+                </div>
+              </>
+            )}
+
+            {(state === "uploading" || state === "parsing") && (
+              <>
+                <Loader2 className="w-8 h-8 text-blue-500 animate-spin" />
+                <p className="text-white font-medium">
+                  {state === "uploading" ? "Uploading…" : "Analysing with AI…"}
+                </p>
+              </>
+            )}
+
+            {state === "success" && (
+              <>
+                <div className="p-3 bg-green-500/10 rounded-full">
+                  <CheckCircle2 className="w-8 h-8 text-green-500" />
+                </div>
+                <p className="text-white font-medium">CV parsed! Redirecting…</p>
+              </>
+            )}
+
+            {state === "failed" && (
+              <div className="space-y-3 max-w-sm">
+                <div className="p-3 bg-red-500/10 rounded-full mx-auto w-fit">
+                  <X className="w-8 h-8 text-red-500" />
+                </div>
+                <p className="text-white font-medium">Parse failed</p>
+                <p className="text-sm text-red-400">{parseError}</p>
+                <div className="flex gap-2 justify-center">
+                  <button
+                    onClick={() => { setState("idle"); setParseError(null); setCurrentCvId(null); }}
+                    className="px-4 py-2 bg-[#1E3A5F] hover:bg-[#2A4B75] text-white rounded-lg text-sm font-medium transition-colors"
+                  >
+                    Try Again
+                  </button>
+                  {currentCvId && (
+                    <button
+                      onClick={() => {
+                        setState("parsing");
+                        setParseError(null);
+                        fetch("/api/cv/parse", {
+                          method: "POST",
+                          headers: { "Content-Type": "application/json" },
+                          body: JSON.stringify({ cvId: currentCvId }),
+                        }).catch(() => null);
+                      }}
+                      className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-medium transition-colors"
+                    >
+                      Retry Parse
+                    </button>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Skip */}
+        <div className="text-center mt-6">
+          <Link
+            href="/dashboard"
+            className="text-xs text-gray-500 hover:text-gray-300 transition-colors inline-flex items-center gap-1"
+          >
+            Skip for now — I&apos;ll add my CV later
+            <ArrowRight className="w-3 h-3" />
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/onboarding/first-analysis/page.tsx
+++ b/src/app/(auth)/onboarding/first-analysis/page.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Briefcase, Loader2, ArrowRight, CheckCircle2 } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+
+export default function OnboardingFirstAnalysisPage() {
+  const router = useRouter();
+  const supabase = createClient();
+  const [jobTitle, setJobTitle] = useState("");
+  const [company, setCompany] = useState("");
+  const [jobText, setJobText] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [hasCv, setHasCv] = useState(false);
+  const [cvId, setCvId] = useState<string | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (!user) { router.push("/login"); return; }
+      supabase.from("cvs").select("id").eq("user_id", user.id).eq("is_active", true).maybeSingle().then(({ data }) => {
+        if (data) { setHasCv(true); setCvId(data.id); }
+      });
+    });
+  }, [supabase, router]);
+
+  const handleAnalyse = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!cvId) { toast.error("No CV found. Please upload your CV first."); return; }
+    setLoading(true);
+    try {
+      const res = await fetch("/api/jobs/analyze", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cvId, jobTitle: jobTitle.trim(), company: company.trim() || undefined, jobRawText: jobText.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Analysis failed");
+
+      // Mark onboarding complete
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        await supabase.from("profiles").update({ onboarding_completed_at: new Date().toISOString() }).eq("id", user.id);
+      }
+
+      toast.success("Analysis complete! Welcome to CareerPilot.");
+      router.push(`/jobs/${data.id}`);
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Something went wrong");
+      setLoading(false);
+    }
+  };
+
+  const handleSkip = async () => {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      await supabase.from("profiles").update({ onboarding_completed_at: new Date().toISOString() }).eq("id", user.id);
+    }
+    router.push("/dashboard");
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6" style={{ background: "var(--bg-base)" }}>
+      <div className="w-full max-w-xl">
+        {/* Logo */}
+        <div className="text-center mb-10">
+          <span className="text-2xl font-extrabold tracking-tight" style={{ fontFamily: "var(--font-heading)", color: "#F1F5F9" }}>
+            Career<span style={{ color: "#2563EB" }}>Pilot</span>
+          </span>
+        </div>
+
+        {hasCv && (
+          <div className="flex items-center gap-2 text-sm text-green-400 mb-4 justify-center">
+            <CheckCircle2 className="w-4 h-4" />
+            CV uploaded and ready
+          </div>
+        )}
+
+        <div className="bg-[#111827] border border-[#1E3A5F] rounded-2xl p-8 space-y-6">
+          <div className="text-center space-y-2">
+            <div className="flex items-center justify-center w-12 h-12 bg-blue-500/10 rounded-full mx-auto mb-4">
+              <Briefcase className="w-6 h-6 text-blue-400" />
+            </div>
+            <h1 className="text-2xl font-extrabold text-white" style={{ fontFamily: "var(--font-heading)" }}>
+              Try your first job analysis
+            </h1>
+            <p className="text-gray-400 text-sm leading-relaxed">
+              Paste a job listing you&apos;re interested in. We&apos;ll tell you in 30 seconds if it&apos;s worth your time.
+            </p>
+          </div>
+
+          <form onSubmit={handleAnalyse} className="space-y-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-gray-400">Job Title *</label>
+                <input
+                  required
+                  value={jobTitle}
+                  onChange={(e) => setJobTitle(e.target.value)}
+                  placeholder="e.g. Senior Frontend Engineer"
+                  className="w-full bg-[#0A0F1C] border border-[#1E3A5F] rounded-lg px-3 py-2.5 text-white text-sm placeholder:text-gray-600 focus:outline-none focus:border-blue-500 transition-colors"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-gray-400">Company (optional)</label>
+                <input
+                  value={company}
+                  onChange={(e) => setCompany(e.target.value)}
+                  placeholder="e.g. Stripe"
+                  className="w-full bg-[#0A0F1C] border border-[#1E3A5F] rounded-lg px-3 py-2.5 text-white text-sm placeholder:text-gray-600 focus:outline-none focus:border-blue-500 transition-colors"
+                />
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-xs font-medium text-gray-400">Job Description *</label>
+              <textarea
+                required
+                rows={7}
+                value={jobText}
+                onChange={(e) => setJobText(e.target.value)}
+                placeholder="Paste the full job description here…"
+                className="w-full bg-[#0A0F1C] border border-[#1E3A5F] rounded-lg px-3 py-2.5 text-white text-sm placeholder:text-gray-600 focus:outline-none focus:border-blue-500 transition-colors resize-none leading-relaxed"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={loading || !jobTitle.trim() || !jobText.trim()}
+              className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white font-semibold rounded-lg transition-colors"
+            >
+              {loading ? (
+                <><Loader2 className="w-4 h-4 animate-spin" /> Analysing…</>
+              ) : (
+                <>Analyse This Job</>
+              )}
+            </button>
+          </form>
+        </div>
+
+        <div className="text-center mt-6">
+          <button
+            onClick={handleSkip}
+            className="text-xs text-gray-500 hover:text-gray-300 transition-colors inline-flex items-center gap-1"
+          >
+            Skip — go to dashboard
+            <ArrowRight className="w-3 h-3" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -7,6 +7,8 @@ import { RecentInterviewsWidget } from "@/components/dashboard/RecentInterviewsW
 import { CareerRoadmapWidget } from "@/components/dashboard/CareerRoadmapWidget";
 import { ApplicationsWidget } from "@/components/dashboard/ApplicationsWidget";
 import { SkillsGapWidget } from "@/components/dashboard/SkillsGapWidget";
+import { FollowUpWidget } from "@/components/dashboard/FollowUpWidget";
+import { NoCvBanner } from "@/components/dashboard/NoCvBanner";
 
 export default async function DashboardPage() {
   const supabase = await createClient();
@@ -15,7 +17,10 @@ export default async function DashboardPage() {
   if (!user) redirect("/login");
 
   // All data fetched in parallel
-  const [cvResult, jobsResult, interviewsResult, roadmapResult, profileResult, appsResult] =
+  // eslint-disable-next-line react-hooks/purity
+  const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [cvResult, jobsResult, interviewsResult, roadmapResult, profileResult, appsResult, followUpResult] =
     await Promise.all([
       supabase
         .from("cvs")
@@ -57,14 +62,25 @@ export default async function DashboardPage() {
         .select("*")
         .eq("user_id", user.id)
         .order("created_at", { ascending: false }),
+
+      // Applications needing follow-up: 'applied' status, applied_at >= 10 days ago, no follow_up_sent_at
+      supabase
+        .from("applications")
+        .select("*")
+        .eq("user_id", user.id)
+        .eq("status", "applied")
+        .not("applied_at", "is", null)
+        .lte("applied_at", tenDaysAgo)
+        .is("follow_up_sent_at", null),
     ]);
 
-  const cv           = (cvResult.data as Cv | null) ?? null;
-  const jobs         = (jobsResult.data as JobAnalysis[]) ?? [];
-  const interviews   = (interviewsResult.data as InterviewSession[]) ?? [];
-  const roadmap      = (roadmapResult.data as CareerRoadmap | null) ?? null;
-  const profile      = profileResult?.data as { full_name: string } | null;
-  const applications = (appsResult.data as Application[]) ?? [];
+  const cv             = (cvResult.data as Cv | null) ?? null;
+  const jobs           = (jobsResult.data as JobAnalysis[]) ?? [];
+  const interviews     = (interviewsResult.data as InterviewSession[]) ?? [];
+  const roadmap        = (roadmapResult.data as CareerRoadmap | null) ?? null;
+  const profile        = profileResult?.data as { full_name: string } | null;
+  const applications   = (appsResult.data as Application[]) ?? [];
+  const followUpApps   = (followUpResult.data as Application[]) ?? [];
 
   const displayName = profile?.full_name || user.email?.split("@")[0] || "there";
 
@@ -78,6 +94,12 @@ export default async function DashboardPage() {
           Here&apos;s an overview of your CareerPilot activity.
         </p>
       </div>
+
+      {/* No-CV banner — shown until CV is uploaded */}
+      {!cv && <NoCvBanner />}
+
+      {/* Follow-up reminders widget */}
+      {followUpApps.length > 0 && <FollowUpWidget applications={followUpApps} />}
 
       {/* 2×2 grid for core widgets */}
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">

--- a/src/app/(dashboard)/interview/[id]/page.tsx
+++ b/src/app/(dashboard)/interview/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { redirect, notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { ActiveSession } from "@/components/interview/ActiveSession";
+import { ChatSession } from "@/components/interview/ChatSession";
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -44,14 +45,25 @@ export default async function InterviewSessionPage({ params }: PageProps) {
     );
   }
 
+  const isAdaptive = (sessionData as { mode?: string }).mode === "adaptive";
+
   return (
     <div className="max-w-4xl mx-auto py-8">
-      <ActiveSession 
-        sessionId={sessionData.id} 
-        questions={questions} 
-        jobTitle={sessionData.job_analyses?.job_title || "Mock Interview"}
-        company={sessionData.job_analyses?.company || ""}
-      />
+      {isAdaptive ? (
+        <ChatSession
+          sessionId={sessionData.id}
+          initialQuestions={questions}
+          jobTitle={sessionData.job_analyses?.job_title || "Mock Interview"}
+          company={sessionData.job_analyses?.company || ""}
+        />
+      ) : (
+        <ActiveSession
+          sessionId={sessionData.id}
+          questions={questions}
+          jobTitle={sessionData.job_analyses?.job_title || "Mock Interview"}
+          company={sessionData.job_analyses?.company || ""}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/(dashboard)/jobs/[id]/page.tsx
+++ b/src/app/(dashboard)/jobs/[id]/page.tsx
@@ -1,9 +1,11 @@
 import { redirect, notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
-import { JobAnalysis, SalaryEstimate } from "@/types";
+import { JobAnalysis, SalaryEstimate, ParsedCvData, TailoredCv } from "@/types";
 import { FitScoreArc } from "@/components/jobs/FitScoreArc";
 import { TrackApplicationButton } from "@/components/jobs/TrackApplicationButton";
 import { ConfidenceBadge } from "@/components/ui/ConfidenceBadge";
+import { TailoredCvView } from "@/components/cv/TailoredCvView";
+import { CompanyContextPanel } from "@/components/jobs/CompanyContextPanel";
 import Link from "next/link";
 import {
   ArrowLeft,
@@ -17,6 +19,7 @@ import {
   DollarSign,
   TrendingUp,
   Info,
+  Wand2,
 } from "lucide-react";
 
 interface PageProps {
@@ -94,16 +97,17 @@ export default async function JobAnalysisResultPage({ params }: PageProps) {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const { data: analysisData, error } = await supabase
-    .from("job_analyses")
-    .select("*")
-    .eq("id", analysisId)
-    .eq("user_id", user.id)
-    .single();
+  const [{ data: analysisData, error }, cvResult, tailoredResult] = await Promise.all([
+    supabase.from("job_analyses").select("*").eq("id", analysisId).eq("user_id", user.id).single(),
+    supabase.from("cvs").select("parsed_data").eq("user_id", user.id).eq("is_active", true).maybeSingle(),
+    supabase.from("tailored_cvs").select("*").eq("job_analysis_id", analysisId).eq("user_id", user.id).maybeSingle(),
+  ]);
 
   if (error || !analysisData) notFound();
 
   const analysis = analysisData as JobAnalysis;
+  const parsedCv = (cvResult.data?.parsed_data as ParsedCvData | null) ?? null;
+  const existingTailored = tailoredResult.data as TailoredCv | null;
 
   const rec = analysis.recommendation || "maybe";
   let recTheme = "bg-yellow-500/10 text-yellow-500 border-yellow-500/20";
@@ -220,6 +224,24 @@ export default async function JobAnalysisResultPage({ params }: PageProps) {
             </h3>
           </div>
           <SalarySection salary={analysis.salary_estimate} />
+        </div>
+      )}
+
+      {/* Company Context */}
+      {analysis.company && <CompanyContextPanel company={analysis.company} />}
+
+      {/* CV Tailoring */}
+      {parsedCv && (
+        <div className="bg-[#111827] border border-[#1E3A5F] rounded-xl p-6 space-y-4">
+          <div className="flex items-center gap-2 text-white pb-3 border-b border-[#1E3A5F]">
+            <Wand2 className="w-5 h-5 text-blue-400" />
+            <h3 className="text-lg font-bold" style={{ fontFamily: "var(--font-heading)" }}>Tailor CV for This Role</h3>
+          </div>
+          <TailoredCvView
+            jobAnalysisId={analysis.id}
+            originalCv={parsedCv}
+            initialTailored={existingTailored ?? undefined}
+          />
         </div>
       )}
 

--- a/src/app/api/applications/follow-up/route.ts
+++ b/src/app/api/applications/follow-up/route.ts
@@ -1,0 +1,112 @@
+import { createClient } from "@/lib/supabase/server";
+import { checkRateLimit, consumeRateLimit } from "@/lib/rateLimit";
+import { generateText } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { generateFollowUpSchema } from "@/lib/validation/schemas";
+import { buildFollowUpEmailPrompt } from "@/lib/ai/prompts";
+import { logger } from "@/lib/logger";
+import { errorResponse, successResponse, rateLimitResponse } from "@/lib/apiResponse";
+import { ParsedCvData } from "@/types";
+
+export const maxDuration = 60;
+
+export async function POST(req: Request) {
+  try {
+    let body: unknown;
+    try { body = await req.json(); } catch { return errorResponse("Invalid JSON body", 400); }
+
+    const parsed = generateFollowUpSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message, 400);
+
+    const { applicationId } = parsed.data;
+
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return errorResponse("Unauthorized", 401);
+
+    // Fetch the application
+    const { data: app, error: appError } = await supabase
+      .from("applications")
+      .select("*")
+      .eq("id", applicationId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (appError || !app) return errorResponse("Application not found", 404);
+
+    // Fetch active CV for the candidate's role
+    const { data: cvData } = await supabase
+      .from("cvs")
+      .select("parsed_data")
+      .eq("user_id", user.id)
+      .eq("is_active", true)
+      .maybeSingle();
+
+    const cvRole = (cvData?.parsed_data as ParsedCvData | null)?.current_role ?? "professional";
+
+    const rateLimit = await checkRateLimit(supabase, user.id, "/api/applications/follow-up");
+    if (!rateLimit.allowed) return rateLimitResponse(rateLimit.message!);
+
+    const prompt = buildFollowUpEmailPrompt(
+      app.job_title,
+      app.company,
+      app.applied_at ?? app.created_at,
+      cvRole
+    );
+
+    const { text } = await generateText({
+      model: anthropic("claude-haiku-4-5"),
+      prompt,
+    });
+
+    await consumeRateLimit(supabase, user.id, "/api/applications/follow-up");
+
+    // Persist the draft to the application row
+    const { data: updated, error: updateError } = await supabase
+      .from("applications")
+      .update({ follow_up_draft: text.trim() })
+      .eq("id", applicationId)
+      .eq("user_id", user.id)
+      .select()
+      .single();
+
+    if (updateError) logger.error("Failed to save follow-up draft", { applicationId }, updateError);
+
+    return successResponse({ draft: text.trim(), application: updated });
+  } catch (error: unknown) {
+    logger.error("Follow-up generation error", { route: "/api/applications/follow-up" }, error);
+    return errorResponse("Internal server error", 500);
+  }
+}
+
+export async function PATCH(req: Request) {
+  // Mark follow-up as sent
+  try {
+    let body: unknown;
+    try { body = await req.json(); } catch { return errorResponse("Invalid JSON body", 400); }
+
+    const parsed = generateFollowUpSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message, 400);
+
+    const { applicationId } = parsed.data;
+
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return errorResponse("Unauthorized", 401);
+
+    const { data: updated, error } = await supabase
+      .from("applications")
+      .update({ follow_up_sent_at: new Date().toISOString() })
+      .eq("id", applicationId)
+      .eq("user_id", user.id)
+      .select()
+      .single();
+
+    if (error) return errorResponse("Failed to mark follow-up as sent", 500);
+
+    return successResponse(updated);
+  } catch (error: unknown) {
+    logger.error("Follow-up mark sent error", {}, error);
+    return errorResponse("Internal server error", 500);
+  }
+}

--- a/src/app/api/cv/tailor/route.ts
+++ b/src/app/api/cv/tailor/route.ts
@@ -1,0 +1,167 @@
+import { createClient } from "@/lib/supabase/server";
+import { checkRateLimit, consumeRateLimit } from "@/lib/rateLimit";
+import { generateObject } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { ParsedCvData, JobAnalysis } from "@/types";
+import { tailorCvSchema, TailoredCvOutputSchema } from "@/lib/validation/schemas";
+import { buildCvTailorPrompt } from "@/lib/ai/prompts";
+import { logger } from "@/lib/logger";
+import { errorResponse, successResponse, rateLimitResponse } from "@/lib/apiResponse";
+
+export const maxDuration = 60;
+
+export async function POST(req: Request) {
+  try {
+    let body: unknown;
+    try { body = await req.json(); } catch { return errorResponse("Invalid JSON body", 400); }
+
+    const parsed = tailorCvSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message, 400);
+
+    const { jobAnalysisId } = parsed.data;
+
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return errorResponse("Unauthorized", 401);
+
+    // Fetch job analysis
+    const { data: analysisData, error: analysisError } = await supabase
+      .from("job_analyses")
+      .select("*")
+      .eq("id", jobAnalysisId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (analysisError || !analysisData) return errorResponse("Job analysis not found", 404);
+    const analysis = analysisData as JobAnalysis;
+
+    // Fetch active CV
+    const { data: cvData, error: cvError } = await supabase
+      .from("cvs")
+      .select("*")
+      .eq("user_id", user.id)
+      .eq("is_active", true)
+      .maybeSingle();
+
+    if (cvError || !cvData || !cvData.parsed_data) {
+      return errorResponse("No active parsed CV found. Please upload and parse your CV first.", 400);
+    }
+
+    const cv = cvData.parsed_data as ParsedCvData;
+
+    // Check if a tailored CV already exists for this analysis
+    const { data: existing } = await supabase
+      .from("tailored_cvs")
+      .select("id")
+      .eq("job_analysis_id", jobAnalysisId)
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    const rateLimit = await checkRateLimit(supabase, user.id, "/api/cv/tailor");
+    if (!rateLimit.allowed) return rateLimitResponse(rateLimit.message!);
+
+    const prompt = buildCvTailorPrompt(
+      cv,
+      analysis.job_title,
+      analysis.company ?? undefined,
+      analysis.job_raw_text,
+      analysis.matched_skills ?? [],
+      analysis.missing_skills ?? []
+    );
+
+    const { object } = await generateObject({
+      model: anthropic("claude-haiku-4-5"),
+      schema: TailoredCvOutputSchema,
+      prompt,
+    });
+
+    await consumeRateLimit(supabase, user.id, "/api/cv/tailor");
+
+    // Build tailored ParsedCvData (preserve original fields not in the tailored output)
+    const tailoredData: ParsedCvData = {
+      current_role: cv.current_role,
+      seniority_level: cv.seniority_level,
+      years_of_experience: cv.years_of_experience,
+      skills: object.skills,
+      education: object.education,
+      experience: object.experience,
+      achievements: cv.achievements,
+    };
+
+    let tailoredCvId: string;
+
+    if (existing) {
+      // Update existing
+      const { data: updated, error: updateError } = await supabase
+        .from("tailored_cvs")
+        .update({
+          tailored_data: tailoredData,
+          user_edits: null,
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", existing.id)
+        .select()
+        .single();
+
+      if (updateError) {
+        logger.error("Failed to update tailored CV", { jobAnalysisId }, updateError);
+        return errorResponse("Failed to save tailored CV", 500);
+      }
+      return successResponse({ ...updated, tailoring_notes: object.tailoring_notes, summary: object.summary });
+    } else {
+      // Insert new
+      const { data: inserted, error: insertError } = await supabase
+        .from("tailored_cvs")
+        .insert({
+          user_id: user.id,
+          cv_id: cvData.id,
+          job_analysis_id: jobAnalysisId,
+          tailored_data: tailoredData,
+        })
+        .select()
+        .single();
+
+      if (insertError) {
+        logger.error("Failed to insert tailored CV", { jobAnalysisId }, insertError);
+        return errorResponse("Failed to save tailored CV", 500);
+      }
+      tailoredCvId = inserted.id;
+      return successResponse({ ...inserted, tailoring_notes: object.tailoring_notes, summary: object.summary });
+    }
+
+    // (unreachable but satisfies TS)
+    void tailoredCvId;
+  } catch (error: unknown) {
+    logger.error("CV tailoring error", { route: "/api/cv/tailor" }, error);
+    return errorResponse("Internal server error", 500);
+  }
+}
+
+export async function PATCH(req: Request) {
+  // Save user edits to a tailored CV
+  try {
+    let body: unknown;
+    try { body = await req.json(); } catch { return errorResponse("Invalid JSON body", 400); }
+
+    const { tailoredCvId, userEdits } = body as { tailoredCvId: string; userEdits: unknown };
+    if (!tailoredCvId) return errorResponse("tailoredCvId is required", 400);
+
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return errorResponse("Unauthorized", 401);
+
+    const { data, error } = await supabase
+      .from("tailored_cvs")
+      .update({ user_edits: userEdits, updated_at: new Date().toISOString() })
+      .eq("id", tailoredCvId)
+      .eq("user_id", user.id)
+      .select()
+      .single();
+
+    if (error) return errorResponse("Failed to save edits", 500);
+    return successResponse(data);
+  } catch (error: unknown) {
+    logger.error("Tailored CV PATCH error", {}, error);
+    return errorResponse("Internal server error", 500);
+  }
+}

--- a/src/app/api/interview/[id]/route.ts
+++ b/src/app/api/interview/[id]/route.ts
@@ -2,6 +2,31 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { InterviewQuestion } from "@/types";
 
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: sessionId } = await params;
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const { data: session, error } = await supabase
+      .from("interview_sessions")
+      .select("*")
+      .eq("id", sessionId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (error || !session) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(session);
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Internal error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
 export async function PATCH(
   req: Request,
   { params }: { params: Promise<{ id: string }> }

--- a/src/app/api/interview/generate/route.ts
+++ b/src/app/api/interview/generate/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: Request) {
       return errorResponse(parsed.error.errors[0]?.message ?? "Missing required field: jobTitle", 400);
     }
 
-    const { jobTitle, companyName, jobAnalysisId } = parsed.data;
+    const { jobTitle, companyName, jobAnalysisId, mode } = parsed.data;
 
     const supabase = await createClient();
 
@@ -81,12 +81,16 @@ export async function POST(req: Request) {
       throw new Error("Failed to generate valid interview questions.");
     }
 
+    // Adaptive mode: start with only the first question; subsequent questions are generated turn-by-turn
+    const sessionQuestions = mode === "adaptive" ? [cleanQuestions[0]] : cleanQuestions;
+
     const { data: sessionData, error: sessionError } = await supabase
       .from("interview_sessions")
       .insert({
         user_id: user.id,
         job_analysis_id: jobAnalysisId || null,
-        questions: cleanQuestions,
+        questions: sessionQuestions,
+        mode: mode ?? "standard",
       })
       .select("id")
       .single();
@@ -98,7 +102,7 @@ export async function POST(req: Request) {
 
     await consumeRateLimit(supabase, user.id, "/api/interview/generate");
 
-    return successResponse({ id: sessionData.id });
+    return successResponse({ id: sessionData.id, mode: mode ?? "standard" });
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : "Internal server error";
     logger.error("Interview generation error", { route: "/api/interview/generate" }, error);

--- a/src/app/api/interview/next-turn/route.ts
+++ b/src/app/api/interview/next-turn/route.ts
@@ -1,0 +1,113 @@
+import { createClient } from "@/lib/supabase/server";
+import { checkRateLimit, consumeRateLimit } from "@/lib/rateLimit";
+import { generateObject } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { ParsedCvData } from "@/types";
+import { interviewNextTurnSchema, InterviewNextTurnOutputSchema } from "@/lib/validation/schemas";
+import { buildInterviewNextTurnPrompt } from "@/lib/ai/prompts";
+import { logger } from "@/lib/logger";
+import { errorResponse, successResponse, rateLimitResponse } from "@/lib/apiResponse";
+
+export const maxDuration = 60;
+
+const MAX_PARENT_QUESTIONS = 9;
+
+export async function POST(req: Request) {
+  try {
+    let body: unknown;
+    try { body = await req.json(); } catch { return errorResponse("Invalid JSON body", 400); }
+
+    const parsed = interviewNextTurnSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0].message, 400);
+
+    const { sessionId, questionId, answer, parentQuestionCount } = parsed.data;
+
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return errorResponse("Unauthorized", 401);
+
+    // Fetch the session + the question being answered
+    const { data: sessionData, error: sessionError } = await supabase
+      .from("interview_sessions")
+      .select("*, job_analyses(job_title, company)")
+      .eq("id", sessionId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (sessionError || !sessionData) return errorResponse("Session not found", 404);
+
+    // Find the question in the JSONB array
+    const questions: Array<{
+      id: string;
+      question_text: string;
+      type: string;
+      is_follow_up?: boolean;
+    }> = sessionData.questions ?? [];
+
+    const question = questions.find((q) => q.id === questionId);
+    if (!question) return errorResponse("Question not found in session", 404);
+
+    // Fetch CV for context
+    const { data: cvData } = await supabase
+      .from("cvs")
+      .select("parsed_data")
+      .eq("user_id", user.id)
+      .eq("is_active", true)
+      .maybeSingle();
+
+    if (!cvData?.parsed_data) return errorResponse("No active CV found", 400);
+
+    const cv = cvData.parsed_data as ParsedCvData;
+    const jobTitle = (sessionData.job_analyses as { job_title: string } | null)?.job_title ?? "the role";
+    const company = (sessionData.job_analyses as { company?: string } | null)?.company ?? undefined;
+
+    const rateLimit = await checkRateLimit(supabase, user.id, "/api/interview/next-turn");
+    if (!rateLimit.allowed) return rateLimitResponse(rateLimit.message!);
+
+    const { object } = await generateObject({
+      model: anthropic("claude-haiku-4-5"),
+      schema: InterviewNextTurnOutputSchema,
+      prompt: buildInterviewNextTurnPrompt(
+        cv,
+        jobTitle,
+        company,
+        parentQuestionCount,
+        MAX_PARENT_QUESTIONS,
+        question.question_text,
+        answer,
+        question.type
+      ),
+    });
+
+    await consumeRateLimit(supabase, user.id, "/api/interview/next-turn");
+
+    // If action is next_question or follow_up, append the new question to the session
+    if (object.action !== "end") {
+      const newQuestion = {
+        id: crypto.randomUUID(),
+        question_text: object.text,
+        type: object.question_type ?? question.type,
+        guidance: "",
+        is_follow_up: object.action === "follow_up",
+        parent_id: object.action === "follow_up" ? questionId : null,
+        user_answer: null,
+        score: null,
+        feedback: null,
+      };
+
+      const updatedQuestions = [...questions, newQuestion];
+      await supabase
+        .from("interview_sessions")
+        .update({ questions: updatedQuestions })
+        .eq("id", sessionId)
+        .eq("user_id", user.id);
+
+      return successResponse({ ...object, next_question_id: newQuestion.id });
+    }
+
+    return successResponse(object);
+  } catch (error: unknown) {
+    logger.error("Interview next-turn error", { route: "/api/interview/next-turn" }, error);
+    return errorResponse("Internal server error", 500);
+  }
+}

--- a/src/app/api/jobs/company-context/route.ts
+++ b/src/app/api/jobs/company-context/route.ts
@@ -1,0 +1,72 @@
+import { createClient } from "@/lib/supabase/server";
+import { generateObject } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { companyContextSchema } from "@/lib/validation/schemas";
+import { logger } from "@/lib/logger";
+import { errorResponse, successResponse } from "@/lib/apiResponse";
+import { z } from "zod";
+
+export const maxDuration = 30;
+
+// Server-side in-memory cache: (company_normalized, date) → result
+// Cleared on server restart; good enough for hot traffic within a single deployment
+const cache = new Map<string, { data: CompanyContext; ts: number }>();
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+const CompanyContextOutputSchema = z.object({
+  overview: z.string(),
+  size: z.string(),
+  funding_stage: z.string(),
+  glassdoor_rating: z.number().nullable(),
+  recent_notable: z.string(),
+  layoff_signals: z.string(),
+  disclaimer: z.string(),
+});
+
+type CompanyContext = z.infer<typeof CompanyContextOutputSchema>;
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const companyRaw = searchParams.get("company");
+
+    const parsed = companyContextSchema.safeParse({ company: companyRaw });
+    if (!parsed.success) return errorResponse("company is required", 400);
+
+    const { company } = parsed.data;
+
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return errorResponse("Unauthorized", 401);
+
+    const cacheKey = `${company.toLowerCase().trim()}:${new Date().toISOString().slice(0, 10)}`;
+    const cached = cache.get(cacheKey);
+    if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+      return successResponse(cached.data);
+    }
+
+    const { object } = await generateObject({
+      model: anthropic("claude-haiku-4-5"),
+      schema: CompanyContextOutputSchema,
+      prompt: `Provide factual context about the company "${company}" for a job seeker evaluating whether to apply there.
+
+Return:
+- overview: 1-2 sentences on what the company does, its stage/size, and market position.
+- size: Approximate employee count (e.g. "~2,000 employees" or "seed stage startup, <50 employees"). Use ranges if unsure.
+- funding_stage: One of: "public", "private equity", "late-stage VC (Series C+)", "mid-stage VC (Series A/B)", "seed/angel", "bootstrapped", "unknown"
+- glassdoor_rating: A number 1-5 if you have reasonable confidence, otherwise null.
+- recent_notable: 1 sentence on the most notable recent development (funding round, product launch, acquisition, layoffs, etc.). If nothing notable in last 12 months, say "No major recent news in training data."
+- layoff_signals: 1 sentence on any known layoffs or hiring freezes. If none known, say "No known layoffs in training data."
+- disclaimer: Always return exactly: "Context sourced from AI training data (cutoff: early 2025). Verify with Glassdoor, LinkedIn, and recent news before making decisions."
+
+Be honest about uncertainty. Do not invent specific facts.`,
+    });
+
+    cache.set(cacheKey, { data: object, ts: Date.now() });
+
+    return successResponse(object);
+  } catch (error: unknown) {
+    logger.error("Company context error", { route: "/api/jobs/company-context" }, error);
+    return errorResponse("Failed to fetch company context", 500);
+  }
+}

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -8,6 +8,21 @@ export async function GET(request: Request) {
   if (code) {
     const supabase = await createClient();
     await supabase.auth.exchangeCodeForSession(code);
+
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      // Check if user has completed onboarding
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("onboarding_completed_at")
+        .eq("id", user.id)
+        .single();
+
+      // New users (no onboarding_completed_at) go to CV upload onboarding
+      if (!profile?.onboarding_completed_at) {
+        return NextResponse.redirect(`${origin}/onboarding/cv`);
+      }
+    }
   }
 
   return NextResponse.redirect(`${origin}/dashboard`);

--- a/src/components/cv/TailoredCvView.tsx
+++ b/src/components/cv/TailoredCvView.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Loader2, Wand2, ChevronDown, ChevronUp, Printer, CheckCircle2, Info, X } from "lucide-react";
+import { ParsedCvData, TailoredCv } from "@/types";
+
+interface Props {
+  jobAnalysisId: string;
+  originalCv: ParsedCvData;
+  initialTailored?: TailoredCv & { tailoring_notes?: string[]; summary?: string };
+}
+
+export function TailoredCvView({ jobAnalysisId, originalCv, initialTailored }: Props) {
+  const [tailored, setTailored] = useState(initialTailored ?? null);
+  const [tailoringNotes, setTailoringNotes] = useState<string[]>(initialTailored?.tailoring_notes ?? []);
+  const [summary, setSummary] = useState<string>(initialTailored?.summary ?? "");
+  const [loading, setLoading] = useState(false);
+  const [showNotes, setShowNotes] = useState(false);
+  const [view, setView] = useState<"tailored" | "original">("tailored");
+
+  const generate = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/cv/tailor", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jobAnalysisId }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Tailoring failed");
+      setTailored(data);
+      setTailoringNotes(data.tailoring_notes ?? []);
+      setSummary(data.summary ?? "");
+      setView("tailored");
+      toast.success("CV tailored for this role");
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Failed to tailor CV");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const exportPdf = () => window.print();
+
+  const displayCv: ParsedCvData = view === "tailored" && tailored ? tailored.tailored_data : originalCv;
+
+  return (
+    <div className="space-y-4">
+      {/* Controls */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={generate}
+            disabled={loading}
+            className="flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white text-sm font-semibold rounded-lg transition-colors"
+          >
+            {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Wand2 className="w-4 h-4" />}
+            {tailored ? "Re-tailor" : "Tailor CV for this role"}
+          </button>
+
+          {tailored && (
+            <>
+              <div className="flex rounded-lg border border-[#1E3A5F] overflow-hidden">
+                <button
+                  onClick={() => setView("tailored")}
+                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                    view === "tailored" ? "bg-blue-600 text-white" : "text-gray-400 hover:text-white"
+                  }`}
+                >
+                  Tailored
+                </button>
+                <button
+                  onClick={() => setView("original")}
+                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                    view === "original" ? "bg-blue-600 text-white" : "text-gray-400 hover:text-white"
+                  }`}
+                >
+                  Original
+                </button>
+              </div>
+              <button
+                onClick={() => setShowNotes((v) => !v)}
+                className="flex items-center gap-1 text-xs text-gray-400 hover:text-white transition-colors"
+              >
+                <Info className="w-3.5 h-3.5" />
+                {showNotes ? "Hide" : "Show"} changes
+                {showNotes ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+              </button>
+            </>
+          )}
+        </div>
+        {tailored && (
+          <button
+            onClick={exportPdf}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-[#1E3A5F] hover:bg-[#2A4B75] text-gray-300 hover:text-white border border-[#1E3A5F] rounded-lg text-xs font-medium transition-colors"
+          >
+            <Printer className="w-3.5 h-3.5" />
+            Export PDF
+          </button>
+        )}
+      </div>
+
+      {/* Tailoring notes */}
+      {showNotes && tailoringNotes.length > 0 && (
+        <div className="bg-amber-500/5 border border-amber-500/20 rounded-xl p-4 space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-semibold text-amber-400 uppercase tracking-wider">What was changed</p>
+            <button onClick={() => setShowNotes(false)} className="text-gray-500 hover:text-white">
+              <X className="w-3.5 h-3.5" />
+            </button>
+          </div>
+          <ul className="space-y-1.5">
+            {tailoringNotes.map((note, i) => (
+              <li key={i} className="flex gap-2 text-xs text-gray-300">
+                <CheckCircle2 className="w-3.5 h-3.5 text-amber-400 shrink-0 mt-0.5" />
+                {note}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!tailored && !loading && (
+        <div className="text-center py-8 text-gray-500 text-sm">
+          Click &quot;Tailor CV for this role&quot; to generate a version of your CV optimised for this specific job.
+        </div>
+      )}
+
+      {/* CV Preview */}
+      {tailored && (
+        <div className="bg-white text-gray-900 rounded-xl p-6 sm:p-8 space-y-6 print:shadow-none" id="tailored-cv-print">
+          {/* Summary */}
+          {view === "tailored" && summary && (
+            <div>
+              <h2 className="text-xs font-bold uppercase tracking-widest text-gray-500 mb-1">Professional Summary</h2>
+              <p className="text-sm text-gray-700 leading-relaxed">{summary}</p>
+            </div>
+          )}
+
+          {/* Skills */}
+          <div>
+            <h2 className="text-xs font-bold uppercase tracking-widest text-gray-500 mb-2">Skills</h2>
+            <div className="flex flex-wrap gap-1.5">
+              {displayCv.skills.map((skill, i) => (
+                <span key={i} className="px-2 py-0.5 bg-gray-100 text-gray-700 text-xs rounded font-medium">{skill}</span>
+              ))}
+            </div>
+          </div>
+
+          {/* Experience */}
+          <div>
+            <h2 className="text-xs font-bold uppercase tracking-widest text-gray-500 mb-3">Experience</h2>
+            <div className="space-y-4">
+              {displayCv.experience.map((exp, i) => (
+                <div key={i}>
+                  <div className="flex items-baseline justify-between">
+                    <p className="font-semibold text-sm text-gray-900">{exp.title}</p>
+                    <span className="text-xs text-gray-500">{exp.duration}</span>
+                  </div>
+                  <p className="text-xs text-gray-600 mb-1">{exp.company}</p>
+                  <p className="text-sm text-gray-700 leading-relaxed">{exp.summary}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Education */}
+          {displayCv.education.length > 0 && (
+            <div>
+              <h2 className="text-xs font-bold uppercase tracking-widest text-gray-500 mb-2">Education</h2>
+              <div className="space-y-1">
+                {displayCv.education.map((edu, i) => (
+                  <div key={i}>
+                    <span className="text-sm font-medium text-gray-900">{edu.degree}</span>
+                    <span className="text-xs text-gray-500"> — {edu.institution}{edu.year ? `, ${edu.year}` : ""}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/FollowUpWidget.tsx
+++ b/src/components/dashboard/FollowUpWidget.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Mail, Copy, Check, Loader2, Send, ChevronDown, ChevronUp } from "lucide-react";
+import { Application } from "@/types";
+import { formatDistanceToNow } from "date-fns";
+
+interface Props {
+  applications: Application[];
+}
+
+interface AppState {
+  loading: boolean;
+  draft: string | null;
+  sent: boolean;
+  expanded: boolean;
+}
+
+export function FollowUpWidget({ applications: initialApps }: Props) {
+  const [apps, setApps] = useState<Application[]>(initialApps);
+  const [states, setStates] = useState<Record<string, AppState>>(() =>
+    Object.fromEntries(
+      initialApps.map((a) => [
+        a.id,
+        { loading: false, draft: a.follow_up_draft ?? null, sent: !!a.follow_up_sent_at, expanded: false },
+      ])
+    )
+  );
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const setState = (id: string, patch: Partial<AppState>) =>
+    setStates((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } }));
+
+  const generateDraft = async (app: Application) => {
+    setState(app.id, { loading: true });
+    try {
+      const res = await fetch("/api/applications/follow-up", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ applicationId: app.id }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Generation failed");
+      setState(app.id, { draft: data.draft, expanded: true, loading: false });
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Failed to generate draft");
+      setState(app.id, { loading: false });
+    }
+  };
+
+  const copyDraft = async (id: string, draft: string) => {
+    await navigator.clipboard.writeText(draft);
+    setCopied(id);
+    toast.success("Copied to clipboard");
+    setTimeout(() => setCopied(null), 2000);
+  };
+
+  const markSent = async (id: string) => {
+    const res = await fetch("/api/applications/follow-up", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ applicationId: id }),
+    });
+    if (!res.ok) { toast.error("Failed to mark as sent"); return; }
+    setState(id, { sent: true });
+    setApps((prev) => prev.filter((a) => a.id !== id));
+    toast.success("Marked as sent — we won't remind you again.");
+  };
+
+  const visibleApps = apps.filter((a) => !states[a.id]?.sent);
+  if (visibleApps.length === 0) return null;
+
+  return (
+    <div className="bg-[#111827] border border-amber-500/20 rounded-xl overflow-hidden">
+      <div className="flex items-center gap-3 px-5 py-4 border-b border-[#1E3A5F]">
+        <div className="p-2 bg-amber-500/10 rounded-lg">
+          <Mail className="w-4 h-4 text-amber-400" />
+        </div>
+        <div>
+          <p className="text-sm font-semibold text-white">
+            {visibleApps.length} application{visibleApps.length !== 1 ? "s" : ""} may need a follow-up
+          </p>
+          <p className="text-xs text-gray-400">10+ days since applying with no status change</p>
+        </div>
+      </div>
+
+      <div className="divide-y divide-[#1E3A5F]">
+        {visibleApps.map((app) => {
+          const s = states[app.id];
+          if (!s) return null;
+          return (
+            <div key={app.id} className="p-4 space-y-3">
+              <div className="flex items-start justify-between gap-3 flex-wrap">
+                <div>
+                  <p className="text-sm font-semibold text-white">{app.job_title}</p>
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    {app.company && `${app.company} · `}
+                    Applied {app.applied_at ? formatDistanceToNow(new Date(app.applied_at), { addSuffix: true }) : "recently"}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  {s.draft && (
+                    <button
+                      onClick={() => setState(app.id, { expanded: !s.expanded })}
+                      className="flex items-center gap-1 text-xs text-gray-400 hover:text-white transition-colors"
+                    >
+                      {s.expanded ? <ChevronUp className="w-3.5 h-3.5" /> : <ChevronDown className="w-3.5 h-3.5" />}
+                      {s.expanded ? "Hide" : "Show"} draft
+                    </button>
+                  )}
+                  <button
+                    onClick={() => generateDraft(app)}
+                    disabled={s.loading}
+                    className="flex items-center gap-1.5 px-3 py-1.5 bg-amber-500/10 hover:bg-amber-500/20 text-amber-400 border border-amber-500/20 rounded-lg text-xs font-medium transition-colors disabled:opacity-50"
+                  >
+                    {s.loading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Mail className="w-3.5 h-3.5" />}
+                    {s.draft ? "Regenerate" : "Draft follow-up"}
+                  </button>
+                </div>
+              </div>
+
+              {s.draft && s.expanded && (
+                <div className="space-y-2">
+                  <div className="bg-[#0A0F1C] border border-[#1E3A5F] rounded-lg p-3">
+                    <p className="text-sm text-gray-300 leading-relaxed whitespace-pre-wrap">{s.draft}</p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => copyDraft(app.id, s.draft!)}
+                      className="flex items-center gap-1.5 px-3 py-1.5 bg-[#1E3A5F] hover:bg-[#2A4B75] text-gray-300 hover:text-white rounded-lg text-xs font-medium transition-colors"
+                    >
+                      {copied === app.id ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
+                      Copy
+                    </button>
+                    <button
+                      onClick={() => markSent(app.id)}
+                      className="flex items-center gap-1.5 px-3 py-1.5 bg-green-500/10 hover:bg-green-500/20 text-green-400 border border-green-500/20 rounded-lg text-xs font-medium transition-colors"
+                    >
+                      <Send className="w-3.5 h-3.5" />
+                      I sent it
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/NoCvBanner.tsx
+++ b/src/components/dashboard/NoCvBanner.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import { UploadCloud, ArrowRight } from "lucide-react";
+
+export function NoCvBanner() {
+  return (
+    <div className="flex items-center justify-between gap-4 p-4 bg-blue-600/10 border border-blue-500/30 rounded-xl flex-wrap">
+      <div className="flex items-center gap-3">
+        <div className="p-2 bg-blue-500/10 rounded-lg shrink-0">
+          <UploadCloud className="w-5 h-5 text-blue-400" />
+        </div>
+        <div>
+          <p className="text-sm font-semibold text-white">Upload your CV to unlock all features</p>
+          <p className="text-xs text-gray-400 mt-0.5">
+            Job analysis, interview prep, and career roadmaps all need your CV.
+          </p>
+        </div>
+      </div>
+      <Link
+        href="/cv"
+        className="flex items-center gap-1.5 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold rounded-lg transition-colors shrink-0"
+      >
+        Upload CV <ArrowRight className="w-3.5 h-3.5" />
+      </Link>
+    </div>
+  );
+}

--- a/src/components/interview/ChatSession.tsx
+++ b/src/components/interview/ChatSession.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { experimental_useObject as useObject } from "@ai-sdk/react";
+import { toast } from "sonner";
+import {
+  Building2,
+  SendHorizontal,
+  Loader2,
+  CheckCircle2,
+  ThumbsUp,
+  ArrowUpCircle,
+  MessageSquare,
+  CornerDownRight,
+  Flag,
+} from "lucide-react";
+import { InterviewFeedbackOutputSchema } from "@/lib/validation/schemas";
+
+interface ChatQuestion {
+  id: string;
+  question_text: string;
+  type: "behavioral" | "technical" | "role-specific";
+  guidance: string;
+  is_follow_up?: boolean;
+  parent_id?: string | null;
+  user_answer?: string | null;
+  score?: number | null;
+  feedback?: string | null;
+  strengths?: string[];
+  improvements?: string[];
+  star_coverage?: { situation: boolean; task: boolean; action: boolean; result: boolean };
+}
+
+interface Props {
+  sessionId: string;
+  initialQuestions: ChatQuestion[];
+  jobTitle: string;
+  company?: string;
+}
+
+const MAX_PARENT_QUESTIONS = 9;
+
+export function ChatSession({ sessionId, initialQuestions, jobTitle, company }: Props) {
+  const router = useRouter();
+  const [questions, setQuestions] = useState<ChatQuestion[]>(initialQuestions);
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const [answer, setAnswer] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [gettingNext, setGettingNext] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const currentQ = questions[currentIdx];
+  const parentCount = questions.filter((q) => !q.is_follow_up).length;
+  const isAnswered = !!currentQ?.feedback;
+
+  const { object: streamObj, submit, isLoading } = useObject({
+    api: "/api/interview/feedback",
+    schema: InterviewFeedbackOutputSchema,
+    onFinish: async ({ object: result }: { object: typeof InterviewFeedbackOutputSchema._type | undefined }) => {
+      if (!result) return;
+
+      const updated: ChatQuestion = {
+        ...currentQ,
+        user_answer: answer,
+        feedback: result.feedback,
+        score: result.score,
+        strengths: result.strengths,
+        improvements: result.improvements,
+        star_coverage: result.star_coverage,
+      };
+
+      setQuestions((prev) => prev.map((q, i) => (i === currentIdx ? updated : q)));
+
+      // Persist answer + feedback
+      setIsSaving(true);
+      try {
+        await fetch(`/api/interview/${sessionId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            questionIndex: currentIdx,
+            answer,
+            feedback: result.feedback,
+            score: result.score,
+            star_coverage: result.star_coverage,
+          }),
+        });
+      } catch {
+        toast.error("Failed to sync answer.");
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    onError: () => toast.error("Failed to generate feedback."),
+  });
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [streamObj, currentIdx, gettingNext]);
+
+  const submitAnswer = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!answer.trim() || isAnswered) return;
+    submit({ prompt: answer, question: currentQ.question_text, type: currentQ.type, jobTitle, company });
+  };
+
+  const getNextTurn = async () => {
+    if (gettingNext) return;
+    setGettingNext(true);
+    try {
+      const res = await fetch("/api/interview/next-turn", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId,
+          questionId: currentQ.id,
+          answer: currentQ.user_answer ?? answer,
+          parentQuestionCount: parentCount,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to get next question");
+
+      if (data.action === "end") {
+        setDone(true);
+      } else {
+        // The API has appended the new question to the session — refresh questions from DB
+        const sessionRes = await fetch(`/api/interview/${sessionId}`);
+        if (sessionRes.ok) {
+          const sessionData = await sessionRes.json();
+          if (sessionData.questions) {
+            setQuestions(sessionData.questions);
+            setCurrentIdx(sessionData.questions.length - 1);
+            setAnswer("");
+          }
+        }
+      }
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Failed to advance session");
+    } finally {
+      setGettingNext(false);
+    }
+  };
+
+  const finishSession = async () => {
+    setIsSaving(true);
+    const answered = questions.filter((q) => q.score !== undefined && q.score !== null);
+    if (answered.length > 0) {
+      const avg = Math.round(answered.reduce((s, q) => s + (q.score ?? 0), 0) / answered.length);
+      try {
+        await fetch(`/api/interview/${sessionId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ overall_score: avg }),
+        });
+      } catch { /* non-critical */ }
+    }
+    router.push(`/interview/${sessionId}/results`);
+  };
+
+  const displayFeedback = isAnswered
+    ? { feedback: currentQ.feedback, strengths: currentQ.strengths, improvements: currentQ.improvements, score: currentQ.score, star_coverage: currentQ.star_coverage }
+    : streamObj;
+
+  if (!currentQ) return null;
+
+  return (
+    <div className="space-y-6 animate-fade-in-up">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row items-baseline justify-between gap-4 pb-4 border-b border-[#1E3A5F]">
+        <div>
+          <h1 className="text-xl font-bold text-white" style={{ fontFamily: "var(--font-heading)" }}>
+            {jobTitle} — Adaptive Interview
+          </h1>
+          {company && (
+            <span className="flex items-center gap-1.5 text-gray-400 text-sm mt-1">
+              <Building2 className="w-4 h-4" /> {company}
+            </span>
+          )}
+        </div>
+        <span className="text-sm font-medium text-gray-400 uppercase tracking-wider shrink-0">
+          {parentCount} / {MAX_PARENT_QUESTIONS} questions
+        </span>
+      </div>
+
+      {/* Question history (answered) */}
+      <div className="space-y-4">
+        {questions.slice(0, currentIdx).map((q) => (
+          <div
+            key={q.id}
+            className={`rounded-xl border p-4 space-y-2 ${
+              q.is_follow_up
+                ? "ml-6 border-purple-500/20 bg-purple-500/5"
+                : "border-[#1E3A5F] bg-[#111827]/60"
+            }`}
+          >
+            <div className="flex items-start gap-2">
+              {q.is_follow_up && <CornerDownRight className="w-3.5 h-3.5 text-purple-400 mt-0.5 shrink-0" />}
+              <div className="space-y-1 min-w-0">
+                <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium uppercase tracking-wide border ${
+                  q.type === "behavioral" ? "bg-purple-500/10 text-purple-400 border-purple-500/20" :
+                  q.type === "technical" ? "bg-blue-500/10 text-blue-400 border-blue-500/20" :
+                  "bg-amber-500/10 text-amber-400 border-amber-500/20"
+                }`}>
+                  {q.is_follow_up ? "Follow-up" : q.type}
+                </span>
+                <p className="text-sm text-gray-300 font-medium">&ldquo;{q.question_text}&rdquo;</p>
+                {q.user_answer && (
+                  <p className="text-xs text-gray-500 italic truncate">You: {q.user_answer}</p>
+                )}
+              </div>
+              {q.score !== null && q.score !== undefined && (
+                <span className="ml-auto shrink-0 text-xs font-bold text-green-400 bg-green-500/10 px-2 py-0.5 rounded border border-green-500/20">
+                  {q.score}/100
+                </span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Current question */}
+      {!done && (
+        <div className={`bg-[#111827] rounded-2xl border p-6 sm:p-8 space-y-6 ${
+          currentQ.is_follow_up ? "border-purple-500/30" : "border-[#1E3A5F]"
+        }`}>
+          {currentQ.is_follow_up && (
+            <div className="flex items-center gap-2 text-purple-400 text-xs font-semibold">
+              <CornerDownRight className="w-3.5 h-3.5" />
+              Follow-up question
+            </div>
+          )}
+          <div>
+            <span className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold uppercase tracking-wider border ${
+              currentQ.type === "behavioral" ? "bg-purple-500/10 text-purple-400 border-purple-500/20" :
+              currentQ.type === "technical" ? "bg-blue-500/10 text-blue-400 border-blue-500/20" :
+              "bg-amber-500/10 text-amber-400 border-amber-500/20"
+            }`}>
+              {currentQ.type} Question
+            </span>
+          </div>
+
+          <p className="text-xl sm:text-2xl font-medium text-white leading-relaxed">
+            &ldquo;{currentQ.question_text}&rdquo;
+          </p>
+
+          <form onSubmit={submitAnswer} className="space-y-4 pt-4 border-t border-[#1E3A5F]/50">
+            <label className="block text-sm font-medium text-gray-300">Your Answer</label>
+            <textarea
+              value={answer}
+              onChange={(e) => setAnswer(e.target.value)}
+              disabled={isLoading || isAnswered || isSaving}
+              placeholder="Type your answer exactly as you would say it…"
+              className="w-full h-40 bg-[#0A0F1C] border border-[#1E3A5F] rounded-xl p-4 text-white text-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500/50 resize-none disabled:opacity-60 transition-colors"
+            />
+            {!isAnswered && !isLoading && (
+              <div className="flex justify-end">
+                <button
+                  type="submit"
+                  disabled={!answer.trim() || isSaving}
+                  className="flex items-center gap-2 px-6 py-2.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white font-medium rounded-lg transition-colors text-sm"
+                >
+                  Submit Answer <SendHorizontal className="w-4 h-4" />
+                </button>
+              </div>
+            )}
+          </form>
+
+          {/* Feedback */}
+          {(isLoading || displayFeedback) && (
+            <div className="bg-blue-900/10 border border-blue-500/20 rounded-xl p-6 space-y-5 animate-fade-in-up">
+              <div className="flex items-center gap-2 text-blue-400 font-semibold">
+                <MessageSquare className="w-5 h-5" />
+                AI Feedback
+                {isLoading && <Loader2 className="w-4 h-4 animate-spin ml-auto" />}
+              </div>
+
+              {displayFeedback?.feedback && (
+                <p className="text-sm text-gray-300 leading-relaxed">{displayFeedback.feedback}</p>
+              )}
+
+              {displayFeedback?.strengths && displayFeedback.strengths.length > 0 && (
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold text-green-400 uppercase tracking-wider flex items-center gap-1.5">
+                    <ThumbsUp className="w-3.5 h-3.5" /> Strengths
+                  </p>
+                  <ul className="space-y-1.5">
+                    {displayFeedback.strengths.filter((s): s is string => !!s).map((s, i) => (
+                      <li key={i} className="flex gap-2 text-sm text-gray-300">
+                        <CheckCircle2 className="w-4 h-4 text-green-500 shrink-0 mt-0.5" />{s}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {displayFeedback?.improvements && displayFeedback.improvements.length > 0 && (
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold text-amber-400 uppercase tracking-wider flex items-center gap-1.5">
+                    <ArrowUpCircle className="w-3.5 h-3.5" /> Improvements
+                  </p>
+                  <ul className="space-y-1.5">
+                    {displayFeedback.improvements.filter((s): s is string => !!s).map((s, i) => (
+                      <li key={i} className="flex gap-2 text-sm text-gray-300">
+                        <span className="w-4 h-4 shrink-0 mt-0.5 text-amber-500 font-bold text-xs flex items-center justify-center">{i + 1}</span>
+                        {s}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {displayFeedback?.star_coverage && (
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold text-purple-400 uppercase tracking-wider">STAR Coverage</p>
+                  <div className="grid grid-cols-2 gap-2">
+                    {(["situation", "task", "action", "result"] as const).map((key) => (
+                      <div key={key} className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border text-xs font-medium ${
+                        displayFeedback.star_coverage?.[key]
+                          ? "bg-green-500/10 border-green-500/20 text-green-400"
+                          : "bg-red-500/10 border-red-500/20 text-red-400"
+                      }`}>
+                        <CheckCircle2 className="w-3.5 h-3.5 shrink-0" />
+                        {key.charAt(0).toUpperCase() + key.slice(1)}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {displayFeedback?.score !== undefined && (
+                <div className="inline-flex items-center gap-1.5 px-3 py-1 bg-green-500/10 text-green-400 text-xs font-bold rounded border border-green-500/20">
+                  <CheckCircle2 className="w-4 h-4" /> Score: {displayFeedback.score}/100
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Next action */}
+          {isAnswered && !isLoading && !isSaving && (
+            <div className="flex justify-end gap-3 mt-4 animate-fade-in-up">
+              <button
+                onClick={finishSession}
+                className="flex items-center gap-2 px-5 py-2.5 bg-gray-800 hover:bg-gray-700 text-gray-300 font-medium rounded-lg transition-colors text-sm border border-gray-700"
+              >
+                <Flag className="w-4 h-4" /> Finish session
+              </button>
+              {parentCount < MAX_PARENT_QUESTIONS && !done && (
+                <button
+                  onClick={getNextTurn}
+                  disabled={gettingNext}
+                  className="flex items-center gap-2 px-6 py-2.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white font-medium rounded-lg transition-colors text-sm"
+                >
+                  {gettingNext ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+                  {gettingNext ? "Thinking…" : "Next"}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Done state */}
+      {done && (
+        <div className="text-center py-8 space-y-4 animate-fade-in-up">
+          <div className="flex items-center justify-center w-16 h-16 bg-green-500/10 rounded-full mx-auto">
+            <CheckCircle2 className="w-8 h-8 text-green-400" />
+          </div>
+          <div>
+            <h2 className="text-xl font-bold text-white">Interview complete</h2>
+            <p className="text-gray-400 text-sm mt-1">All questions answered. View your overall results below.</p>
+          </div>
+          <button
+            onClick={finishSession}
+            disabled={isSaving}
+            className="flex items-center gap-2 px-8 py-3 bg-green-600 hover:bg-green-500 text-white font-bold rounded-lg transition-colors mx-auto"
+          >
+            {isSaving ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+            See Results
+          </button>
+        </div>
+      )}
+
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/src/components/interview/NewInterviewForm.tsx
+++ b/src/components/interview/NewInterviewForm.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Briefcase, Building2, PlayCircle, Loader2 } from "lucide-react";
+import { Briefcase, Building2, PlayCircle, Loader2, Zap } from "lucide-react";
 import { useStepCycle } from "@/hooks/useStepCycle";
 
 interface NewInterviewFormProps {
@@ -28,6 +28,7 @@ export function NewInterviewForm({
   const router = useRouter();
   const [targetRole, setTargetRole] = useState(initialJobTitle);
   const [targetCompany, setTargetCompany] = useState(initialCompany);
+  const [mode, setMode] = useState<"standard" | "adaptive">("standard");
   const [loading, setLoading] = useState(false);
   const { stepIndex, start: startStepCycle, stop: stopStepCycle } = useStepCycle(GENERATION_STEPS.length, 4000);
 
@@ -47,6 +48,7 @@ export function NewInterviewForm({
           jobTitle: targetRole.trim(),
           companyName: targetCompany.trim() || undefined,
           jobAnalysisId,
+          mode,
         }),
       });
 
@@ -159,7 +161,37 @@ export function NewInterviewForm({
           </div>
         </div>
 
-        <div className="pt-4 flex justify-end relative z-10">
+        {/* Mode selector */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 relative z-10">
+          <button
+            type="button"
+            onClick={() => setMode("standard")}
+            className={`p-4 rounded-xl border text-left transition-all ${
+              mode === "standard" ? "border-blue-500 bg-blue-500/10" : "border-[#1E3A5F] hover:border-blue-500/40"
+            }`}
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <PlayCircle className="w-4 h-4 text-blue-400" />
+              <span className="text-sm font-semibold text-white">Standard</span>
+            </div>
+            <p className="text-xs text-gray-400">10 pre-generated questions, answer at your own pace.</p>
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode("adaptive")}
+            className={`p-4 rounded-xl border text-left transition-all ${
+              mode === "adaptive" ? "border-purple-500 bg-purple-500/10" : "border-[#1E3A5F] hover:border-purple-500/40"
+            }`}
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <Zap className="w-4 h-4 text-purple-400" />
+              <span className="text-sm font-semibold text-white">Adaptive</span>
+            </div>
+            <p className="text-xs text-gray-400">AI probes your answers with follow-up questions, like a real interview.</p>
+          </button>
+        </div>
+
+        <div className="pt-2 flex justify-end relative z-10">
           <button
             type="submit"
             disabled={loading || !targetRole.trim()}

--- a/src/components/jobs/CompanyContextPanel.tsx
+++ b/src/components/jobs/CompanyContextPanel.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { Building2, Loader2, Star, AlertTriangle, TrendingUp, Users, Info, ChevronDown, ChevronUp } from "lucide-react";
+
+interface CompanyContext {
+  overview: string;
+  size: string;
+  funding_stage: string;
+  glassdoor_rating: number | null;
+  recent_notable: string;
+  layoff_signals: string;
+  disclaimer: string;
+}
+
+interface Props {
+  company: string;
+}
+
+export function CompanyContextPanel({ company }: Props) {
+  const [context, setContext] = useState<CompanyContext | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  const load = async () => {
+    if (loaded && !error) { setCollapsed((v) => !v); return; }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/jobs/company-context?company=${encodeURIComponent(company)}`);
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Failed to fetch");
+      setContext(data);
+      setLoaded(true);
+      setCollapsed(false);
+    } catch {
+      setError("Couldn't fetch company context.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const hasLayoffSignal = context?.layoff_signals && !context.layoff_signals.includes("No known");
+
+  return (
+    <div className="bg-[#111827] border border-[#1E3A5F] rounded-xl overflow-hidden">
+      <button
+        onClick={load}
+        className="w-full flex items-center justify-between p-4 hover:bg-[#1E3A5F]/20 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-blue-500/10 rounded-lg">
+            <Building2 className="w-4 h-4 text-blue-400" />
+          </div>
+          <div className="text-left">
+            <p className="text-sm font-semibold text-white">Company Context — {company}</p>
+            <p className="text-xs text-gray-400">Funding stage, size, recent news, Glassdoor</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {loading && <Loader2 className="w-4 h-4 text-gray-400 animate-spin" />}
+          {loaded && !error && (collapsed ? <ChevronDown className="w-4 h-4 text-gray-400" /> : <ChevronUp className="w-4 h-4 text-gray-400" />)}
+          {!loaded && !loading && <span className="text-xs text-blue-400 font-medium">Load context</span>}
+        </div>
+      </button>
+
+      {error && (
+        <div className="px-4 pb-4">
+          <p className="text-sm text-red-400">{error}</p>
+          <a
+            href={`https://www.google.com/search?q=${encodeURIComponent(company + " company info glassdoor")} `}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-blue-400 hover:underline mt-1 inline-block"
+          >
+            Search manually
+          </a>
+        </div>
+      )}
+
+      {context && !collapsed && (
+        <div className="px-4 pb-4 space-y-4 border-t border-[#1E3A5F] pt-4">
+          {/* Overview */}
+          <p className="text-sm text-gray-300 leading-relaxed">{context.overview}</p>
+
+          {/* Key stats */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <div className="bg-[#0A0F1C] rounded-lg p-3 space-y-1">
+              <div className="flex items-center gap-1.5 text-xs text-gray-500">
+                <Users className="w-3 h-3" /> Size
+              </div>
+              <p className="text-sm font-medium text-white">{context.size}</p>
+            </div>
+            <div className="bg-[#0A0F1C] rounded-lg p-3 space-y-1">
+              <div className="flex items-center gap-1.5 text-xs text-gray-500">
+                <TrendingUp className="w-3 h-3" /> Stage
+              </div>
+              <p className="text-sm font-medium text-white">{context.funding_stage}</p>
+            </div>
+            {context.glassdoor_rating !== null && (
+              <div className="bg-[#0A0F1C] rounded-lg p-3 space-y-1">
+                <div className="flex items-center gap-1.5 text-xs text-gray-500">
+                  <Star className="w-3 h-3" /> Glassdoor
+                </div>
+                <p className="text-sm font-medium text-white">{context.glassdoor_rating}/5</p>
+              </div>
+            )}
+          </div>
+
+          {/* Recent notable */}
+          <div className="flex items-start gap-2">
+            <Info className="w-3.5 h-3.5 text-blue-400 shrink-0 mt-0.5" />
+            <p className="text-xs text-gray-400">{context.recent_notable}</p>
+          </div>
+
+          {/* Layoff signals */}
+          {hasLayoffSignal && (
+            <div className="flex items-start gap-2 bg-red-500/5 border border-red-500/20 rounded-lg p-3">
+              <AlertTriangle className="w-3.5 h-3.5 text-red-400 shrink-0 mt-0.5" />
+              <p className="text-xs text-red-300">{context.layoff_signals}</p>
+            </div>
+          )}
+
+          {/* Disclaimer */}
+          <p className="text-xs text-gray-600 italic border-t border-[#1E3A5F] pt-3">{context.disclaimer}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -150,6 +150,107 @@ INSTRUCTIONS:
 - Output only the letter text itself — no subject line, no headers`;
 }
 
+// ── Follow-up Email ───────────────────────────────────────────────────────────
+export function buildFollowUpEmailPrompt(
+  jobTitle: string,
+  company: string | undefined,
+  appliedAt: string,
+  cvRole: string
+): string {
+  const daysSince = Math.round((Date.now() - new Date(appliedAt).getTime()) / (1000 * 60 * 60 * 24));
+  return `Write a short, polite follow-up message for a job application.
+
+The candidate applied for: ${jobTitle}${company ? ` at ${company}` : ""}
+Days since applying: ${daysSince}
+Candidate's current role: ${cvRole}
+
+Requirements:
+- Under 100 words
+- Professional but warm tone
+- Reference the role and approximately when they applied
+- Ask politely about the status of their application
+- Do NOT use: "I hope this email finds you well", "circle back", "touch base", "leverage", or other clichés
+- Output only the message body — no subject line, no salutation, no sign-off
+- Write it so the candidate can paste it into an email or LinkedIn message with minimal editing`;
+}
+
+// ── CV Tailoring ──────────────────────────────────────────────────────────────
+export function buildCvTailorPrompt(
+  cv: ParsedCvData,
+  jobTitle: string,
+  company: string | undefined,
+  jobRawText: string,
+  matchedSkills: string[],
+  missingSkills: string[]
+): string {
+  return `You are an expert CV writer and career coach.
+
+A candidate wants to tailor their CV for a specific job application.
+
+JOB TITLE: ${jobTitle}
+${company ? `COMPANY: ${company}` : ""}
+
+JOB DESCRIPTION:
+${jobRawText}
+
+CANDIDATE'S CURRENT CV:
+Current Role: ${cv.current_role}
+Seniority: ${cv.seniority_level}
+Years of Experience: ${cv.years_of_experience}
+Skills: ${cv.skills.join(", ")}
+Experience:
+${cv.experience.map((e) => `- ${e.title} at ${e.company} (${e.duration}): ${e.summary}`).join("\n")}
+Education:
+${cv.education.map((e) => `- ${e.degree} at ${e.institution}${e.year ? ` (${e.year})` : ""}`).join("\n")}
+
+MATCHED SKILLS: ${matchedSkills.join(", ") || "none identified"}
+MISSING SKILLS: ${missingSkills.join(", ") || "none"}
+
+Tailor this candidate's CV for the job above. Your output:
+1. skills: Reordered skills list — matched/relevant skills first, irrelevant ones last. Do not add skills the candidate doesn't have.
+2. experience: Rewritten experience bullets emphasising work relevant to this role. Reorder entries to put the most relevant experience first. Do NOT invent or exaggerate — only reframe what's there.
+3. education: Return as-is (no changes usually needed).
+4. summary: One optional 2-sentence professional summary targeting this specific role. Only include if it adds value.
+5. tailoring_notes: 3-5 bullet points explaining what you changed and why, so the candidate understands the strategy.
+
+Be honest: if the candidate is a weak match, say so in tailoring_notes — don't over-promise.`;
+}
+
+// ── Interview Next Turn ───────────────────────────────────────────────────────
+export function buildInterviewNextTurnPrompt(
+  cv: ParsedCvData,
+  jobTitle: string,
+  company: string | undefined,
+  parentQuestionCount: number,
+  maxParentQuestions: number,
+  question: string,
+  answer: string,
+  questionType: string
+): string {
+  return `You are a senior interviewer conducting a mock interview.
+
+ROLE: ${jobTitle}${company ? ` at ${company}` : ""}
+CANDIDATE: ${cv.current_role}, ${cv.years_of_experience} years experience
+
+Current parent question count: ${parentQuestionCount} of ${maxParentQuestions} main questions asked.
+Question just asked (type: ${questionType}): "${question}"
+Candidate's answer: "${answer}"
+
+Decide your next move:
+- "follow_up": The answer was vague, incomplete, or left out a key detail worth probing. Generate a sharp follow-up that would be asked in a real interview.
+- "next_question": The answer was reasonably complete. Move to the next main question. Generate it (behavioral/technical/role-specific, appropriate for their background).
+- "end": We have reached or exceeded ${maxParentQuestions} parent questions AND the current answer is complete. End the session.
+
+Rules:
+- Only choose "follow_up" if the answer genuinely warrants it — don't probe just to probe.
+- Follow-ups don't count toward the ${maxParentQuestions} parent question total.
+- If parentQuestionCount >= ${maxParentQuestions}, only choose "follow_up" if critical, otherwise choose "end".
+- For "next_question": vary the question type from the previous one if possible.
+- text: the exact question or closing statement to show the user.
+- reasoning: 1 sentence explaining your decision (internal only, not shown to user).
+- question_type: only include for "next_question" or "follow_up" actions.`;
+}
+
 // ── Career Roadmap ────────────────────────────────────────────────────────────
 export const CAREER_ROADMAP_SYSTEM_PROMPT = `You are an expert career advisor and technical recruiter.
 Review the candidate's CV and generate 3 distinct, highly realistic career progression paths for them.

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -6,6 +6,8 @@ export const GLOBAL_AI_LIMIT_PER_HOUR = 10;
 export const ROUTE_LIMITS_PER_HOUR: Record<string, number> = {
   "/api/cv/parse": 3,
   "/api/cover-letter/generate": 5,
+  "/api/cv/tailor": 2,
+  "/api/applications/follow-up": 10,
 };
 
 export async function checkRateLimit(

--- a/src/lib/validation/schemas.ts
+++ b/src/lib/validation/schemas.ts
@@ -18,6 +18,7 @@ export const generateInterviewSchema = z.object({
   jobTitle: z.string().min(1, "jobTitle is required").max(200),
   companyName: z.string().max(200).optional(),
   jobAnalysisId: z.string().uuid().optional(),
+  mode: z.enum(["standard", "adaptive"]).optional().default("standard"),
 });
 
 export const interviewFeedbackSchema = z.object({
@@ -85,6 +86,57 @@ export const OUTCOME_STAGES = [
   "offer",
 ] as const;
 
+// ── CV Tailoring ──────────────────────────────────────────────────────────────
+export const tailorCvSchema = z.object({
+  jobAnalysisId: z.string().uuid("jobAnalysisId must be a valid UUID"),
+});
+
+export const TailoredCvOutputSchema = z.object({
+  summary: z.string().optional(),
+  skills: z.array(z.string()),
+  experience: z.array(z.object({
+    title: z.string(),
+    company: z.string(),
+    duration: z.string(),
+    summary: z.string(),
+  })),
+  education: z.array(z.object({
+    degree: z.string(),
+    institution: z.string(),
+    year: z.number().optional(),
+  })),
+  tailoring_notes: z.array(z.string()),
+});
+
+// ── Application Follow-up ─────────────────────────────────────────────────────
+export const generateFollowUpSchema = z.object({
+  applicationId: z.string().uuid("applicationId must be a valid UUID"),
+});
+
+export const markFollowUpSentSchema = z.object({
+  applicationId: z.string().uuid("applicationId must be a valid UUID"),
+});
+
+// ── Company Context ───────────────────────────────────────────────────────────
+export const companyContextSchema = z.object({
+  company: z.string().min(1).max(200),
+});
+
+// ── Adaptive Interview ────────────────────────────────────────────────────────
+export const interviewNextTurnSchema = z.object({
+  sessionId: z.string().uuid("sessionId must be a valid UUID"),
+  questionId: z.string(),
+  answer: z.string().min(1, "answer is required"),
+  parentQuestionCount: z.number().int().min(0),
+});
+
+export const InterviewNextTurnOutputSchema = z.object({
+  action: z.enum(["follow_up", "next_question", "end"]),
+  text: z.string(),
+  reasoning: z.string(),
+  question_type: z.enum(["behavioral", "technical", "role-specific"]).optional(),
+});
+
 export const patchApplicationSchema = z.object({
   status: z.enum(APPLICATION_STATUSES).optional(),
   notes: z.string().max(5000).optional().nullable(),
@@ -96,4 +148,6 @@ export const patchApplicationSchema = z.object({
   outcome_reason: z.string().max(2000).optional().nullable(),
   outcome_fit_score_at_apply: z.number().int().min(0).max(100).optional().nullable(),
   outcome_captured_at: z.string().datetime().optional().nullable(),
+  follow_up_sent_at: z.string().datetime().optional().nullable(),
+  follow_up_draft: z.string().max(5000).optional().nullable(),
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export interface Profile {
   id: string;
   full_name: string | null;
   avatar_url: string | null;
+  onboarding_completed_at: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -148,6 +149,20 @@ export interface Application {
   outcome_reason: string | null;
   outcome_fit_score_at_apply: number | null;
   outcome_captured_at: string | null;
+  follow_up_sent_at: string | null;
+  follow_up_draft: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// ── Tailored CV ───────────────────────────────────────────────────────────────
+export interface TailoredCv {
+  id: string;
+  user_id: string;
+  cv_id: string;
+  job_analysis_id: string;
+  tailored_data: ParsedCvData;
+  user_edits: Partial<ParsedCvData> | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
T1-1 Per-job CV tailoring
- New tailored_cvs table (schema + RLS)
- POST /api/cv/tailor — generates role-tailored CV via Claude, persists to DB
- PATCH /api/cv/tailor — saves user edits
- TailoredCvView component: tailored vs original toggle, tailoring notes, PDF export
- Rate limited 2/hr; surfaced on job analysis detail page

T1-2 Adaptive interview mode with follow-up questions
- POST /api/interview/next-turn — decides follow_up / next_question / end using Claude
- GET /api/interview/[id] — session refresh for chat UI
- ChatSession component: chat-like UI, follow-ups nested under parent, finish at any time
- NewInterviewForm: Standard vs Adaptive mode selector
- Interview session page detects mode and renders the appropriate component

T1-3 Application follow-up reminders
- follow_up_sent_at + follow_up_draft columns added to applications (schema + types)
- POST /api/applications/follow-up — generates draft follow-up email via Claude
- PATCH /api/applications/follow-up — marks as sent
- FollowUpWidget on dashboard: surfaces stale applied applications (≥10 days, no follow-up)
- Rate limited 10/hr; draft persisted to DB

T1-4 Company context panel on Job Analyzer
- GET /api/jobs/company-context — uses Claude training data (overview, size, funding stage, Glassdoor rating, recent news, layoff signals) with clear disclaimer
- 24-hour in-process cache keyed by (company, date)
- CompanyContextPanel component: lazy-loaded, collapsible, graceful degradation

T1-5 First-session activation flow
- onboarding_completed_at column on profiles (schema + types)
- Auth callback redirects new users to /onboarding/cv, returning users to /dashboard
- /onboarding/cv — minimal CV upload page (no sidebar, skip link)
- /onboarding/first-analysis — first job analysis, marks onboarding complete on submit
- NoCvBanner on dashboard: persistent until CV is uploaded

Close #55 
Close #56 
Close #57 
Close #58 
Close #59 