### PR TITLE
feat: implement all Design/UX issues (D-1 through D-4)

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -215,6 +215,20 @@ CREATE INDEX IF NOT EXISTS idx_cohort_stats_lookup
   ON cohort_stats(seniority_level, role_family, experience_bracket, computed_at DESC);
 
 -- -----------------------------------------------------------------------------
+-- demo_rate_limits
+-- Throttles unauthenticated job-listing demo to 1 request per IP per day.
+-- ip_hash is SHA-256 of the IP address (never store raw IPs).
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS demo_rate_limits (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  ip_hash    TEXT        NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_demo_rate_limits_ip_time
+  ON demo_rate_limits(ip_hash, created_at DESC);
+
+-- -----------------------------------------------------------------------------
 -- rate_limit_events
 -- Tracks AI request events for per-user rate limiting.
 -- -----------------------------------------------------------------------------

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { toast } from "sonner";
+import { createClient } from "@/lib/supabase/client";
+import { ArrowLeft, Loader2, Check } from "lucide-react";
+
+export default function ForgotPasswordPage() {
+  const supabase = createClient();
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  const handleReset = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/auth/callback?type=recovery`,
+    });
+    setLoading(false);
+    if (error) {
+      // Generic message — don't confirm whether email exists
+      toast.error("Something went wrong. Try again in a moment.");
+      return;
+    }
+    setSent(true);
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center">
+          <span className="text-2xl font-extrabold tracking-tight" style={{ fontFamily: "var(--font-heading)" }}>
+            Career<span className="text-blue-500">Pilot</span>
+          </span>
+        </div>
+
+        <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--card-bg)] p-7 space-y-5">
+          {sent ? (
+            <div className="text-center py-6 space-y-3">
+              <div className="w-12 h-12 rounded-full bg-green-500/10 border border-green-500/20 flex items-center justify-center mx-auto">
+                <Check className="w-6 h-6 text-green-400" />
+              </div>
+              <p className="font-semibold text-white">Check your inbox</p>
+              <p className="text-sm text-gray-400">
+                If <span className="text-white">{email}</span> has an account, we sent a reset link.
+              </p>
+              <Link href="/login" className="inline-flex items-center gap-1.5 text-sm text-blue-400 hover:underline mt-2">
+                <ArrowLeft className="w-3.5 h-3.5" /> Back to login
+              </Link>
+            </div>
+          ) : (
+            <>
+              <div>
+                <h1 className="text-lg font-bold text-white">Reset your password</h1>
+                <p className="text-sm text-gray-400 mt-1">
+                  Enter your email and we&apos;ll send a reset link.
+                </p>
+              </div>
+
+              <form onSubmit={handleReset} className="space-y-4">
+                <div>
+                  <label className="auth-label" htmlFor="email">Email</label>
+                  <input
+                    id="email"
+                    type="email"
+                    required
+                    className="auth-input"
+                    placeholder="you@example.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                  />
+                </div>
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="btn-primary w-full flex items-center justify-center gap-2"
+                >
+                  {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+                  Send reset link
+                </button>
+              </form>
+
+              <Link
+                href="/login"
+                className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-300 transition-colors"
+              >
+                <ArrowLeft className="w-3.5 h-3.5" /> Back to login
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -5,103 +5,204 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
+import { Loader2 } from "lucide-react";
+
+// ── OAuth provider SVGs ───────────────────────────────────────────────────────
+function GoogleIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+      <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.874 2.684-6.615z" fill="#4285F4"/>
+      <path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z" fill="#34A853"/>
+      <path d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"/>
+      <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335"/>
+    </svg>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
+    </svg>
+  );
+}
 
 export default function LoginPage() {
   const router = useRouter();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [loading, setLoading] = useState(false);
-
   const supabase = createClient();
 
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const [mode, setMode] = useState<"oauth" | "magic" | "password">("oauth");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState<string | null>(null);
+  const [magicSent, setMagicSent] = useState(false);
 
-    setLoading(true);
-
-    const { error } = await supabase.auth.signInWithPassword({
-      email,
-      password,
+  const handleOAuth = async (provider: "google" | "github") => {
+    setLoading(provider);
+    await supabase.auth.signInWithOAuth({
+      provider,
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
     });
+  };
 
-    if (error) {
-      // Always show generic error for security
-      toast.error("Invalid email or password");
-      setLoading(false);
-      return;
-    }
+  const handleMagicLink = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading("magic");
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
+    });
+    setLoading(null);
+    if (error) { toast.error("Couldn't send link — check the email address."); return; }
+    setMagicSent(true);
+  };
 
+  const handlePassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading("password");
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    setLoading(null);
+    if (error) { toast.error("Invalid email or password"); return; }
     toast.success("Welcome back!");
     router.push("/dashboard");
   };
 
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
-      <div
-        className="w-full max-w-md p-8 rounded-xl"
-        style={{
-          background: "var(--card-bg)",
-          border: "1px solid var(--border-subtle)",
-        }}
-      >
-        <div className="text-center mb-8">
-          <h1
-            className="text-2xl font-bold"
-            style={{ fontFamily: "var(--font-heading)" }}
-          >
-            Welcome Back
-          </h1>
-          <p className="text-sm mt-2" style={{ color: "#94A3B8" }}>
-            Log in to CareerPilot to continue
-          </p>
+      <div className="w-full max-w-md space-y-6">
+        {/* Logo */}
+        <div className="text-center">
+          <span className="text-2xl font-extrabold tracking-tight" style={{ fontFamily: "var(--font-heading)" }}>
+            Career<span className="text-blue-500">Pilot</span>
+          </span>
+          <p className="text-sm text-gray-400 mt-2">Welcome back</p>
         </div>
 
-        <form onSubmit={handleLogin} className="flex flex-col gap-5">
-          <div>
-            <label className="auth-label" htmlFor="email">
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              required
-              className="auth-input"
-              placeholder="you@example.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-            />
+        <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--card-bg)] p-7 space-y-5">
+          {/* OAuth buttons */}
+          <div className="grid grid-cols-2 gap-3">
+            <button
+              onClick={() => handleOAuth("google")}
+              disabled={loading !== null}
+              className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-[var(--border-subtle)] bg-white/5 hover:bg-white/10 text-sm font-medium text-gray-200 transition-colors disabled:opacity-50"
+            >
+              {loading === "google" ? <Loader2 className="w-4 h-4 animate-spin" /> : <GoogleIcon />}
+              Google
+            </button>
+            <button
+              onClick={() => handleOAuth("github")}
+              disabled={loading !== null}
+              className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-[var(--border-subtle)] bg-white/5 hover:bg-white/10 text-sm font-medium text-gray-200 transition-colors disabled:opacity-50"
+            >
+              {loading === "github" ? <Loader2 className="w-4 h-4 animate-spin" /> : <GitHubIcon />}
+              GitHub
+            </button>
           </div>
 
-          <div>
-            <label className="auth-label" htmlFor="password">
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              required
-              className="auth-input"
-              placeholder="••••••••"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
+          <div className="flex items-center gap-3">
+            <div className="flex-1 h-px bg-[var(--border-subtle)]" />
+            <span className="text-xs text-gray-500">or</span>
+            <div className="flex-1 h-px bg-[var(--border-subtle)]" />
           </div>
 
-          <button type="submit" className="btn-primary mt-2" disabled={loading}>
-            {loading ? "Logging in..." : "Log In"}
-          </button>
-        </form>
+          {/* Magic link */}
+          {mode !== "password" && (
+            <>
+              {magicSent ? (
+                <div className="text-center py-4 space-y-2">
+                  <p className="text-sm font-medium text-white">Check your inbox</p>
+                  <p className="text-xs text-gray-400">We sent a sign-in link to <span className="text-white">{email}</span>.</p>
+                  <button onClick={() => { setMagicSent(false); setEmail(""); }} className="text-xs text-blue-400 hover:underline mt-2">
+                    Use a different email
+                  </button>
+                </div>
+              ) : (
+                <form onSubmit={handleMagicLink} className="space-y-3">
+                  <input
+                    type="email"
+                    required
+                    className="auth-input"
+                    placeholder="you@example.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                  />
+                  <button
+                    type="submit"
+                    disabled={loading !== null}
+                    className="btn-primary w-full flex items-center justify-center gap-2"
+                  >
+                    {loading === "magic" ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+                    Send sign-in link
+                  </button>
+                </form>
+              )}
 
-        <div className="mt-6 text-center text-sm" style={{ color: "#94A3B8" }}>
-          Don&apos;t have an account?{" "}
-          <Link
-            href="/signup"
-            style={{ color: "var(--accent)" }}
-            className="hover:underline transition-colors"
-          >
-            Sign up
+              <button
+                onClick={() => setMode("password")}
+                className="w-full text-center text-xs text-gray-500 hover:text-gray-300 transition-colors"
+              >
+                Use a password instead →
+              </button>
+            </>
+          )}
+
+          {/* Password fallback */}
+          {mode === "password" && (
+            <form onSubmit={handlePassword} className="space-y-4">
+              <div>
+                <label className="auth-label" htmlFor="email">Email</label>
+                <input
+                  id="email"
+                  type="email"
+                  required
+                  className="auth-input"
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                />
+              </div>
+              <div>
+                <div className="flex items-center justify-between mb-1">
+                  <label className="auth-label" htmlFor="password">Password</label>
+                  <Link href="/forgot-password" className="text-xs text-blue-400 hover:underline">
+                    Forgot password?
+                  </Link>
+                </div>
+                <input
+                  id="password"
+                  type="password"
+                  required
+                  className="auth-input"
+                  placeholder="••••••••"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={loading !== null}
+                className="btn-primary w-full flex items-center justify-center gap-2 mt-2"
+              >
+                {loading === "password" ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+                Log In
+              </button>
+              <button
+                type="button"
+                onClick={() => setMode("oauth")}
+                className="w-full text-center text-xs text-gray-500 hover:text-gray-300 transition-colors"
+              >
+                ← Back to sign-in options
+              </button>
+            </form>
+          )}
+        </div>
+
+        <p className="text-center text-sm text-gray-500">
+          No account?{" "}
+          <Link href="/signup" className="text-blue-400 hover:underline">
+            Sign up free
           </Link>
-        </div>
+        </p>
       </div>
     </div>
   );

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -5,17 +5,67 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
+import { Loader2, Check, X } from "lucide-react";
+
+function GoogleIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+      <path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844c-.209 1.125-.843 2.078-1.796 2.717v2.258h2.908c1.702-1.567 2.684-3.874 2.684-6.615z" fill="#4285F4"/>
+      <path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18z" fill="#34A853"/>
+      <path d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"/>
+      <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335"/>
+    </svg>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
+    </svg>
+  );
+}
+
+function StrengthBar({ password }: { password: string }) {
+  const checks = [
+    { label: "8+ characters", ok: password.length >= 8 },
+    { label: "Number", ok: /[0-9]/.test(password) },
+    { label: "Special character", ok: /[!@#$%^&*(),.?":{}|<>]/.test(password) },
+  ];
+  const score = checks.filter((c) => c.ok).length;
+  const colors = ["bg-red-500", "bg-amber-500", "bg-amber-400", "bg-green-500"];
+
+  if (!password) return null;
+
+  return (
+    <div className="mt-2 space-y-1.5">
+      <div className="flex gap-1">
+        {[0, 1, 2].map((i) => (
+          <div key={i} className={`h-1 flex-1 rounded-full transition-colors ${i < score ? colors[score] : "bg-white/10"}`} />
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-x-3 gap-y-1">
+        {checks.map((c) => (
+          <span key={c.label} className={`flex items-center gap-1 text-[10px] ${c.ok ? "text-green-400" : "text-gray-500"}`}>
+            {c.ok ? <Check className="w-2.5 h-2.5" /> : <X className="w-2.5 h-2.5" />}
+            {c.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export default function SignupPage() {
-  const [displayName, setDisplayName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [loading, setLoading] = useState(false);
+  const [displayName, setDisplayName] = useState("");
+  const [loading, setLoading] = useState<string | null>(null);
+  const [emailSent, setEmailSent] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const router = useRouter();
   const supabase = createClient();
 
-  // Handle immediate redirect if the user confirms email in another tab
   useEffect(() => {
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       if (event === "SIGNED_IN" && session) {
@@ -23,154 +73,185 @@ export default function SignupPage() {
         router.push("/dashboard");
       }
     });
-
     return () => subscription.unsubscribe();
   }, [supabase, router]);
 
-  const validatePassword = (pw: string) => {
-    if (pw.length < 8) return "Password must be at least 8 characters long";
-    if (!/[0-9]/.test(pw)) return "Password must contain at least one number";
-    if (!/[!@#$%^&*(),.?\":{}|<>]/.test(pw)) return "Password must contain at least one special character";
-    return null;
+  const handleOAuth = async (provider: "google" | "github") => {
+    setLoading(provider);
+    await supabase.auth.signInWithOAuth({
+      provider,
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
+    });
   };
+
+  const isPasswordValid = password.length >= 8 && /[0-9]/.test(password) && /[!@#$%^&*(),.?":{}|<>]/.test(password);
 
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault();
-
-    const passwordError = validatePassword(password);
-    if (passwordError) {
-      toast.error(passwordError);
-      return;
-    }
-
-    if (password !== confirmPassword) {
-      toast.error("Passwords do not match");
-      return;
-    }
-
-    if (!displayName.trim()) {
-      toast.error("Please enter a display name");
-      return;
-    }
-
-    if (displayName.trim().length > 50) {
-      toast.error("Display name must be 50 characters or less");
-      return;
-    }
-
-    setLoading(true);
-
+    if (!isPasswordValid) { toast.error("Password doesn't meet requirements"); return; }
+    setLoading("email");
     const { error } = await supabase.auth.signUp({
       email,
       password,
       options: {
-        data: { full_name: displayName.trim() },
+        data: displayName.trim() ? { full_name: displayName.trim() } : {},
         emailRedirectTo: `${window.location.origin}/auth/callback`,
       },
     });
-
-    if (error) {
-      toast.error(error.message);
-      setLoading(false);
-      return;
-    }
-
-    toast.success("Check your email to confirm your account!");
-    // Don't set loading to false here, to show "Waiting for confirmation..." state if desired
-    // Or just keep it as is.
-    setLoading(false);
+    setLoading(null);
+    if (error) { toast.error("Something went wrong — try again."); return; }
+    setEmailSent(true);
   };
 
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
-      <div 
-        className="w-full max-w-md p-8 rounded-xl"
-        style={{
-          background: "var(--card-bg)",
-          border: "1px solid var(--border-subtle)",
-        }}
-      >
-        <div className="text-center mb-8">
-          <h1 className="text-2xl font-bold" style={{ fontFamily: "var(--font-heading)" }}>
-            Create an Account
-          </h1>
-          <p className="text-sm mt-2" style={{ color: "#94A3B8" }}>
-            Start your journey with CareerPilot
-          </p>
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center">
+          <span className="text-2xl font-extrabold tracking-tight" style={{ fontFamily: "var(--font-heading)" }}>
+            Career<span className="text-blue-500">Pilot</span>
+          </span>
+          <p className="text-sm text-gray-400 mt-2">Free. No credit card.</p>
         </div>
 
-        <form onSubmit={handleSignup} className="flex flex-col gap-5">
-          <div>
-            <label className="auth-label" htmlFor="displayName">Display Name</label>
-            <input
-              id="displayName"
-              type="text"
-              required
-              maxLength={50}
-              className="auth-input"
-              placeholder="e.g. Samir"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-            />
-          </div>
+        <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--card-bg)] p-7 space-y-5">
+          {emailSent ? (
+            <div className="text-center py-6 space-y-3">
+              <div className="w-12 h-12 rounded-full bg-blue-500/10 border border-blue-500/20 flex items-center justify-center mx-auto">
+                <Check className="w-6 h-6 text-blue-400" />
+              </div>
+              <p className="font-semibold text-white">Check your inbox</p>
+              <p className="text-sm text-gray-400">
+                We sent a confirmation link to <span className="text-white">{email}</span>.
+                <br />Click it to activate your account.
+              </p>
+              <button onClick={() => setEmailSent(false)} className="text-xs text-blue-400 hover:underline mt-2">
+                Use a different email
+              </button>
+            </div>
+          ) : (
+            <>
+              {/* OAuth */}
+              <div className="grid grid-cols-2 gap-3">
+                <button
+                  onClick={() => handleOAuth("google")}
+                  disabled={loading !== null}
+                  className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-[var(--border-subtle)] bg-white/5 hover:bg-white/10 text-sm font-medium text-gray-200 transition-colors disabled:opacity-50"
+                >
+                  {loading === "google" ? <Loader2 className="w-4 h-4 animate-spin" /> : <GoogleIcon />}
+                  Google
+                </button>
+                <button
+                  onClick={() => handleOAuth("github")}
+                  disabled={loading !== null}
+                  className="flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-[var(--border-subtle)] bg-white/5 hover:bg-white/10 text-sm font-medium text-gray-200 transition-colors disabled:opacity-50"
+                >
+                  {loading === "github" ? <Loader2 className="w-4 h-4 animate-spin" /> : <GitHubIcon />}
+                  GitHub
+                </button>
+              </div>
 
-          <div>
-            <label className="auth-label" htmlFor="email">Email</label>
-            <input
-              id="email"
-              type="email"
-              required
-              className="auth-input"
-              placeholder="you@example.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-            />
-          </div>
+              {!showPassword ? (
+                <>
+                  <div className="flex items-center gap-3">
+                    <div className="flex-1 h-px bg-[var(--border-subtle)]" />
+                    <span className="text-xs text-gray-500">or sign up with email</span>
+                    <div className="flex-1 h-px bg-[var(--border-subtle)]" />
+                  </div>
 
-          <div>
-            <label className="auth-label" htmlFor="password">Password</label>
-            <input
-              id="password"
-              type="password"
-              required
-              className="auth-input"
-              placeholder="••••••••"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
-            <p className="text-[10px] mt-1.5 opacity-60 leading-relaxed">
-              Minimum 8 characters, at least one number and one special character.
-            </p>
-          </div>
+                  <div className="space-y-3">
+                    <input
+                      type="email"
+                      required
+                      className="auth-input"
+                      placeholder="you@example.com"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                    />
+                    <button
+                      onClick={() => { if (email) setShowPassword(true); }}
+                      disabled={!email}
+                      className="btn-primary w-full disabled:opacity-40"
+                    >
+                      Continue with email
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="flex items-center gap-3">
+                    <div className="flex-1 h-px bg-[var(--border-subtle)]" />
+                    <span className="text-xs text-gray-500">or use a password</span>
+                    <div className="flex-1 h-px bg-[var(--border-subtle)]" />
+                  </div>
 
-          <div>
-            <label className="auth-label" htmlFor="confirmPassword">Confirm Password</label>
-            <input
-              id="confirmPassword"
-              type="password"
-              required
-              className="auth-input"
-              placeholder="••••••••"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-            />
-          </div>
+                  <form onSubmit={handleSignup} className="space-y-4">
+                    <div>
+                      <label className="auth-label">Email</label>
+                      <input
+                        type="email"
+                        required
+                        className="auth-input"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                      />
+                    </div>
 
-          <button
-            type="submit"
-            className="btn-primary mt-2"
-            disabled={loading}
-          >
-            {loading ? "Creating account..." : "Sign Up"}
-          </button>
-        </form>
+                    <div>
+                      <label className="auth-label">
+                        Name <span className="text-gray-600 font-normal">(optional)</span>
+                      </label>
+                      <input
+                        type="text"
+                        maxLength={50}
+                        className="auth-input"
+                        placeholder="e.g. Samir"
+                        value={displayName}
+                        onChange={(e) => setDisplayName(e.target.value)}
+                      />
+                    </div>
 
-        <div className="mt-6 text-center text-sm" style={{ color: "#94A3B8" }}>
+                    <div>
+                      <label className="auth-label">Password</label>
+                      <input
+                        type="password"
+                        required
+                        className="auth-input"
+                        placeholder="••••••••"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                      />
+                      <StrengthBar password={password} />
+                    </div>
+
+                    <button
+                      type="submit"
+                      disabled={loading !== null || !isPasswordValid}
+                      className="btn-primary w-full flex items-center justify-center gap-2 mt-2 disabled:opacity-40"
+                    >
+                      {loading === "email" ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+                      Create account
+                    </button>
+
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(false)}
+                      className="w-full text-center text-xs text-gray-500 hover:text-gray-300 transition-colors"
+                    >
+                      ← Back to sign-up options
+                    </button>
+                  </form>
+                </>
+              )}
+            </>
+          )}
+        </div>
+
+        <p className="text-center text-sm text-gray-500">
           Already have an account?{" "}
-          <Link href="/login" style={{ color: "var(--accent)" }} className="hover:underline transition-colors">
-            Log In
+          <Link href="/login" className="text-blue-400 hover:underline">
+            Log in
           </Link>
-        </div>
+        </p>
       </div>
     </div>
   );

--- a/src/app/(dashboard)/analytics/loading.tsx
+++ b/src/app/(dashboard)/analytics/loading.tsx
@@ -4,12 +4,12 @@ export default function Loading() {
       <div className="h-8 w-32 rounded-lg bg-white/5" />
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
         {[...Array(4)].map((_, i) => (
-          <div key={i} className="h-24 rounded-xl bg-[#111827] border border-white/5" />
+          <div key={i} className="h-24 rounded-xl bg-[var(--card-bg)] border border-white/5" />
         ))}
       </div>
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-        <div className="h-56 rounded-xl bg-[#111827] border border-white/5" />
-        <div className="h-56 rounded-xl bg-[#111827] border border-white/5" />
+        <div className="h-56 rounded-xl bg-[var(--card-bg)] border border-white/5" />
+        <div className="h-56 rounded-xl bg-[var(--card-bg)] border border-white/5" />
       </div>
     </div>
   );

--- a/src/app/api/jobs/demo-analyze/route.ts
+++ b/src/app/api/jobs/demo-analyze/route.ts
@@ -1,0 +1,92 @@
+import { createAdminClient } from "@/lib/supabase/server";
+import { generateObject } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { z } from "zod";
+import { logger } from "@/lib/logger";
+import { errorResponse, successResponse } from "@/lib/apiResponse";
+import { NextRequest } from "next/server";
+import { createHash } from "crypto";
+
+export const maxDuration = 30;
+
+const requestSchema = z.object({
+  jobRawText: z.string().min(50, "Paste at least 50 characters of the job listing").max(8000),
+});
+
+function getIp(req: NextRequest): string {
+  return (
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    req.headers.get("x-real-ip") ||
+    "unknown"
+  );
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    let body: unknown;
+    try { body = await req.json(); } catch { return errorResponse("Invalid JSON body", 400); }
+
+    const parsed = requestSchema.safeParse(body);
+    if (!parsed.success) return errorResponse(parsed.error.errors[0]?.message ?? "Invalid input", 400);
+
+    const { jobRawText } = parsed.data;
+    const ip = getIp(req);
+    const ipHash = createHash("sha256").update(ip).digest("hex");
+
+    // Rate limit: 1 per IP per 24 hours
+    const supabase = createAdminClient();
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+    const { data: existing } = await supabase
+      .from("demo_rate_limits")
+      .select("id")
+      .eq("ip_hash", ipHash)
+      .gte("created_at", oneDayAgo)
+      .limit(1)
+      .maybeSingle();
+
+    if (existing) {
+      return errorResponse(
+        "You've used the demo today. Sign up for free to analyse your own CV against any role.",
+        429
+      );
+    }
+
+    const { object } = await generateObject({
+      model: anthropic("claude-haiku-4-5"),
+      schema: z.object({
+        role_title: z.string(),
+        seniority_level: z.enum(["Junior", "Mid", "Senior", "Lead", "Principal"]),
+        role_family: z.string(),
+        top_required_skills: z.array(z.string()).max(6),
+        nice_to_have_skills: z.array(z.string()).max(4),
+        key_responsibilities: z.array(z.string()).max(4),
+        what_makes_a_strong_candidate: z.string(),
+        red_flags_to_watch: z.array(z.string()).max(3),
+      }),
+      prompt: `Parse this job listing and extract structured insights a job seeker would find useful.
+
+JOB LISTING:
+${jobRawText}
+
+Extract:
+- role_title: canonical job title
+- seniority_level: inferred level
+- role_family: e.g. "Software Engineering", "Product Management", "Design"
+- top_required_skills: the 4-6 skills that are hard requirements
+- nice_to_have_skills: preferred but not required
+- key_responsibilities: 3-4 core things this role actually does day-to-day
+- what_makes_a_strong_candidate: 1-2 sentences on what separates a 90th-percentile applicant
+- red_flags_to_watch: 1-3 things in the listing that might indicate role is worse than it sounds (vague scope, "wear many hats" without clarity, etc). Empty array if listing is clean.`,
+    });
+
+    // Record rate limit after successful AI call
+    await supabase.from("demo_rate_limits").insert({ ip_hash: ipHash });
+
+    return successResponse({ analysis: object });
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : "Internal server error";
+    logger.error("Demo analyze error", { route: "/api/jobs/demo-analyze" }, error);
+    return errorResponse(message, 500);
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,104 +1,71 @@
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import { LandingDemo } from "@/components/landing/LandingDemo";
 
-// ── Feature card data ─────────────────────────────────────────────────────────
-const features = [
+// ── Scenario cards ─────────────────────────────────────────────────────────────
+const scenarios = [
   {
-    emoji: "📄",
-    title: "Smart CV Parsing",
-    description:
-      "Upload your CV once. Our AI reads your PDF and extracts your entire profile to power deeply personalised insights across every tool.",
+    trigger: "I saw a listing at 10pm",
+    question: "Should I even apply?",
+    answer: "Paste the listing. Get a fit score, missing skills, and an honest recommendation in 30 seconds.",
+    href: "/signup",
+    cta: "Try it free",
+    color: "border-blue-500/30 hover:border-blue-500/60",
+    badge: "Job Analyzer",
+    badgeColor: "bg-blue-500/10 text-blue-300 border-blue-500/20",
   },
   {
-    emoji: "🎯",
-    title: "Job Analyser",
-    description:
-      "Paste any job listing and get an instant fit score, matched skills, and a personalised skill gap analysis.",
+    trigger: "I got rejected yesterday",
+    question: "What went wrong?",
+    answer: "CareerPilot captures your outcomes and runs a post-mortem: likely gap, what similar candidates did next, what to add to your roadmap.",
+    href: "/signup",
+    cta: "Start tracking",
+    color: "border-orange-500/30 hover:border-orange-500/60",
+    badge: "Rejection Post-Mortem",
+    badgeColor: "bg-orange-500/10 text-orange-300 border-orange-500/20",
   },
   {
-    emoji: "📝",
-    title: "Cover Letters",
-    description:
-      "Generate tailored, highly personalised cover letters instantly based on your CV and the specific job requirements.",
-  },
-  {
-    emoji: "📋",
-    title: "Application Tracker",
-    description:
-      "Keep all your applications organised in one place. Save notes, track statuses, and never lose a job link again.",
-  },
-  {
-    emoji: "🎤",
-    title: "Interview Coach",
-    description:
-      "Practice with AI-generated questions tailored to the exact role and your background. Get scored, actionable feedback.",
-  },
-  {
-    emoji: "📈",
-    title: "Career Ladder",
-    description:
-      "See exactly what skills to build, what projects to ship, and how long it realistically takes to reach the next level.",
+    trigger: "I have an interview Tuesday",
+    question: "Am I actually ready?",
+    answer: "Practice with an AI interviewer that knows your CV and the exact role. Follow-up questions included — just like a real interview.",
+    href: "/signup",
+    cta: "Start practising",
+    color: "border-green-500/30 hover:border-green-500/60",
+    badge: "Interview Coach",
+    badgeColor: "bg-green-500/10 text-green-300 border-green-500/20",
   },
 ];
 
-// ── SVG dot-grid background (20×20 tile) ──────────────────────────────────────
-const DOT_GRID = `url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='1' cy='1' r='1' fill='%231E3A5F'/%3E%3C/svg%3E")`;
+// ── Feature grid (secondary — demoted below scenarios) ────────────────────────
+const features = [
+  { emoji: "📄", title: "Smart CV Parsing", description: "Upload once. Your profile powers every tool — fit scores, interview questions, cover letters, career paths." },
+  { emoji: "🎯", title: "Job Analyser", description: "Fit score with a rubric, matched and missing skills, salary context, and a tailored CV — all from one paste." },
+  { emoji: "📋", title: "Application Tracker", description: "Track status, capture outcomes, and get rejection post-mortems. Your history teaches the AI to predict better." },
+  { emoji: "🎤", title: "Interview Coach", description: "Adaptive mock interviews that follow up on vague answers. Score trends by question type across all sessions." },
+  { emoji: "📈", title: "Career Ladder", description: "A living roadmap — track skills, mark them done, and watch your CV auto-complete items on the next upload." },
+  { emoji: "📊", title: "Analytics", description: "Prescriptive, not descriptive. Calibration drift, rejection patterns, and cohort benchmarks against peers." },
+];
 
-// ── Page ──────────────────────────────────────────────────────────────────────
 export default async function LandingPage() {
-  // Server-side auth check — authenticated users go straight to dashboard
   const supabase = await createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  if (session) {
-    redirect("/dashboard");
-  }
+  const { data: { session } } = await supabase.auth.getSession();
+  if (session) redirect("/dashboard");
 
   return (
-    <div
-      style={{
-        backgroundColor: "#0A0F1C",
-        color: "#F1F5F9",
-        minHeight: "100vh",
-        fontFamily: "var(--font-body)",
-      }}
-    >
-      {/* ── Navbar ───────────────────────────────────────────────────────────── */}
-      <nav
-        style={{ borderBottom: "1px solid #1E3A5F" }}
-        className="sticky top-0 z-50 backdrop-blur-sm"
-      >
-        <div
-          style={{ backgroundColor: "rgba(10,15,28,0.85)" }}
-          className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between"
-        >
-          {/* Logo */}
-          <span
-            className="text-xl font-extrabold tracking-tight"
-            style={{ fontFamily: "var(--font-heading)", color: "#F1F5F9" }}
-          >
-            Career<span style={{ color: "#2563EB" }}>Pilot</span>
-          </span>
+    <div className="bg-[var(--background)] text-[var(--foreground)] min-h-screen font-[var(--font-body)]">
 
-          {/* Nav actions */}
+      {/* ── Navbar ───────────────────────────────────────────────────────────── */}
+      <nav className="sticky top-0 z-50 backdrop-blur-sm border-b border-[var(--border-subtle)] bg-[var(--background)]/85">
+        <div className="max-w-7xl mx-auto px-6 py-4 flex items-center justify-between">
+          <span className="text-xl font-extrabold tracking-tight" style={{ fontFamily: "var(--font-heading)" }}>
+            Career<span className="text-blue-500">Pilot</span>
+          </span>
           <div className="flex items-center gap-3">
-            <Link
-              href="/login"
-              className="nav-link text-sm font-medium px-4 py-2 rounded-lg transition-colors"
-            >
+            <Link href="/login" className="nav-link text-sm font-medium px-4 py-2 rounded-lg transition-colors">
               Log In
             </Link>
-            <Link
-              href="/signup"
-              className="text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
-              style={{
-                backgroundColor: "#2563EB",
-                color: "#FFFFFF",
-              }}
-            >
+            <Link href="/signup" className="text-sm font-semibold px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white transition-colors">
               Get Started
             </Link>
           </div>
@@ -106,158 +73,123 @@ export default async function LandingPage() {
       </nav>
 
       {/* ── Hero ─────────────────────────────────────────────────────────────── */}
-      <section
-        className="relative flex items-center justify-center overflow-hidden"
-        style={{
-          minHeight: "calc(100vh - 65px)",
-          backgroundImage: DOT_GRID,
-        }}
-      >
-        {/* Radial glow behind the headline */}
+      <section className="relative flex flex-col items-center justify-center overflow-hidden px-6 pt-20 pb-16 text-center">
+        {/* Background glow */}
+        <div aria-hidden className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="h-[500px] w-full max-w-2xl rounded-full bg-blue-600/10 blur-3xl" />
+        </div>
+
+        {/* Dot grid */}
         <div
-          aria-hidden="true"
-          style={{
-            position: "absolute",
-            top: "50%",
-            left: "50%",
-            transform: "translate(-50%, -50%)",
-            width: "100%",
-            height: "600px",
-            background:
-              "radial-gradient(ellipse at center, rgba(37,99,235,0.15) 0%, transparent 70%)",
-            pointerEvents: "none",
-          }}
+          aria-hidden
+          className="pointer-events-none absolute inset-0 opacity-40"
+          style={{ backgroundImage: "url(\"data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='1' cy='1' r='1' fill='%231E3A5F'/%3E%3C/svg%3E\")" }}
         />
 
-        {/* Content */}
-        <div className="relative z-10 text-center px-6 max-w-3xl mx-auto flex flex-col items-center gap-8">
-          {/* Badge */}
-          <div
-            className="animate-fade-in-up inline-flex items-center gap-2 text-xs font-semibold px-3 py-1 rounded-full"
-            style={{
-              border: "1px solid #1E3A5F",
-              color: "#60A5FA",
-              backgroundColor: "rgba(37,99,235,0.08)",
-            }}
-          >
-            <span
-              className="w-1.5 h-1.5 rounded-full"
-              style={{ backgroundColor: "#2563EB" }}
-            />
+        <div className="relative z-10 flex flex-col items-center gap-6 max-w-3xl mx-auto">
+          <div className="animate-fade-in-up inline-flex items-center gap-2 text-xs font-semibold px-3 py-1 rounded-full border border-[var(--border-subtle)] text-blue-400 bg-blue-600/8">
+            <span className="w-1.5 h-1.5 rounded-full bg-blue-500" />
             AI-Powered · Built for Ambitious Professionals
           </div>
 
-          {/* Headline */}
-          <h1
-            className="animate-fade-in-up delay-100 text-5xl md:text-6xl font-extrabold leading-tight tracking-tight"
-            style={{ fontFamily: "var(--font-heading)", color: "#F1F5F9" }}
-          >
-            Your AI{" "}
-            <span
-              style={{
-                background: "linear-gradient(135deg, #2563EB 0%, #60A5FA 100%)",
-                WebkitBackgroundClip: "text",
-                WebkitTextFillColor: "transparent",
-                backgroundClip: "text",
-              }}
-            >
-              Career Co-Pilot
-            </span>
+          <h1 className="animate-fade-in-up delay-100 text-5xl md:text-6xl font-extrabold leading-tight tracking-tight" style={{ fontFamily: "var(--font-heading)" }}>
+            Paste a job listing.{" "}
+            <span className="bg-gradient-to-r from-blue-500 to-blue-300 bg-clip-text text-transparent">
+              Know in 30 seconds
+            </span>{" "}
+            if it&apos;s worth your time.
           </h1>
 
-          {/* Subheadline */}
-          <p
-            className="animate-fade-in-up delay-200 text-xl leading-relaxed max-w-xl"
-            style={{ color: "#94A3B8" }}
-          >
-            Analyse job fits, practise interviews, and map your path to the next
-            level — all in one place.
+          <p className="animate-fade-in-up delay-200 text-lg text-gray-400 max-w-xl leading-relaxed">
+            CareerPilot scores your fit, identifies gaps, preps your interview, and learns from every outcome — all from your CV.
           </p>
 
-          {/* CTA buttons */}
-          <div className="animate-fade-in-up delay-300 flex flex-col sm:flex-row items-center gap-4">
-            <Link
-              id="cta-get-started"
-              href="/signup"
-              className="w-full sm:w-auto text-sm font-semibold px-8 py-3 rounded-xl transition-all"
-              style={{
-                backgroundColor: "#2563EB",
-                color: "#FFFFFF",
-                boxShadow: "0 0 20px rgba(37,99,235,0.35)",
-              }}
-            >
-              Get Started — it&apos;s free
-            </Link>
-            <Link
-              id="cta-log-in"
-              href="/login"
-              className="w-full sm:w-auto text-sm font-semibold px-8 py-3 rounded-xl transition-all"
-              style={{
-                border: "1px solid #2563EB",
-                color: "#60A5FA",
-              }}
-            >
-              Log In
-            </Link>
+          {/* Inline demo */}
+          <div className="animate-fade-in-up delay-300 w-full max-w-2xl">
+            <LandingDemo />
           </div>
+
+          <p className="animate-fade-in-up delay-300 text-xs text-gray-600">
+            No account needed for the demo. &nbsp;
+            <Link href="/signup" className="text-blue-400 hover:underline">Sign up free</Link>
+            {" "}to analyse against your CV.
+          </p>
         </div>
       </section>
 
-      {/* ── Features ─────────────────────────────────────────────────────────── */}
-      <section className="max-w-7xl mx-auto px-6 py-24">
-        <div className="text-center mb-16">
-          <h2
-            className="text-3xl md:text-4xl font-extrabold mb-4"
-            style={{ fontFamily: "var(--font-heading)", color: "#F1F5F9" }}
-          >
-            Everything your career needs
-          </h2>
-          <p style={{ color: "#64748B" }} className="text-lg max-w-xl mx-auto">
-            A comprehensive suite of tools, one seamless workflow.
-          </p>
-        </div>
-
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-          {features.map((feature, i) => (
+      {/* ── Scenario cards ────────────────────────────────────────────────────── */}
+      <section className="max-w-6xl mx-auto px-6 py-16">
+        <h2 className="text-center text-sm font-bold uppercase tracking-widest text-gray-500 mb-10">
+          Common triggers
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+          {scenarios.map((s) => (
             <div
-              key={feature.title}
-              className={`animate-fade-in-up delay-${(i + 2) * 100} flex flex-col gap-4`}
-              style={{
-                background: "#111827",
-                border: "1px solid #1E3A5F",
-                borderRadius: "12px",
-                padding: "24px",
-              }}
+              key={s.trigger}
+              className={`flex flex-col gap-4 rounded-2xl border bg-[var(--card-bg)] p-6 transition-colors ${s.color}`}
             >
-              <span className="text-4xl" role="img" aria-label={feature.title}>
-                {feature.emoji}
-              </span>
-              <h3
-                className="text-lg font-bold"
-                style={{
-                  fontFamily: "var(--font-heading)",
-                  color: "#F1F5F9",
-                }}
+              <div>
+                <span className={`inline-block text-xs font-bold px-2.5 py-1 rounded-full border mb-3 ${s.badgeColor}`}>
+                  {s.badge}
+                </span>
+                <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">{s.trigger}</p>
+                <h3 className="text-lg font-bold text-white mt-1" style={{ fontFamily: "var(--font-heading)" }}>
+                  {s.question}
+                </h3>
+              </div>
+              <p className="text-sm text-gray-400 leading-relaxed flex-1">{s.answer}</p>
+              <Link
+                href={s.href}
+                className="inline-flex items-center gap-1 text-sm font-semibold text-blue-400 hover:text-blue-300 transition-colors"
               >
-                {feature.title}
-              </h3>
-              <p className="text-sm leading-relaxed" style={{ color: "#64748B" }}>
-                {feature.description}
-              </p>
+                {s.cta} →
+              </Link>
             </div>
           ))}
         </div>
       </section>
 
+      {/* ── Feature grid ──────────────────────────────────────────────────────── */}
+      <section className="max-w-7xl mx-auto px-6 py-16 border-t border-[var(--border-subtle)]">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl md:text-4xl font-extrabold mb-3" style={{ fontFamily: "var(--font-heading)" }}>
+            Everything in one place
+          </h2>
+          <p className="text-gray-500 text-lg max-w-xl mx-auto">
+            Seven tools. One CV. One workflow.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+          {features.map((f, i) => (
+            <div
+              key={f.title}
+              className={`animate-fade-in-up delay-${(i + 1) * 100} flex flex-col gap-3 rounded-xl border border-[var(--border-subtle)] bg-[var(--card-bg)] p-6`}
+            >
+              <span className="text-3xl" role="img" aria-label={f.title}>{f.emoji}</span>
+              <h3 className="text-base font-bold text-white" style={{ fontFamily: "var(--font-heading)" }}>{f.title}</h3>
+              <p className="text-sm text-gray-500 leading-relaxed">{f.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── CTA strip ─────────────────────────────────────────────────────────── */}
+      <section className="border-t border-[var(--border-subtle)] py-16 text-center px-6">
+        <h2 className="text-2xl font-extrabold text-white mb-4" style={{ fontFamily: "var(--font-heading)" }}>
+          Ready to stop guessing?
+        </h2>
+        <Link
+          href="/signup"
+          className="inline-flex items-center gap-2 px-8 py-3 rounded-xl bg-blue-600 hover:bg-blue-500 text-white font-semibold transition-colors shadow-lg shadow-blue-900/30 text-sm"
+        >
+          Get started — it&apos;s free
+        </Link>
+      </section>
+
       {/* ── Footer ───────────────────────────────────────────────────────────── */}
-      <footer
-        className="text-center py-8 text-sm"
-        style={{
-          borderTop: "1px solid #1E3A5F",
-          color: "#334155",
-        }}
-      >
-        CareerPilot &copy; 2025
+      <footer className="text-center py-8 text-sm text-gray-700 border-t border-[var(--border-subtle)]">
+        CareerPilot &copy; {new Date().getFullYear()}
       </footer>
     </div>
   );

--- a/src/components/analytics/AnalyticsClient.tsx
+++ b/src/components/analytics/AnalyticsClient.tsx
@@ -126,7 +126,7 @@ export function AnalyticsClient({ applications, jobs, interviews }: Props) {
         </div>
         <Link
           href="/interview/progress"
-          className="inline-flex items-center gap-2 px-4 py-2 bg-[#111827] border border-white/10 hover:border-blue-500/40 text-gray-300 hover:text-white text-sm font-medium rounded-lg transition-colors"
+          className="inline-flex items-center gap-2 px-4 py-2 bg-[var(--card-bg)] border border-white/10 hover:border-blue-500/40 text-gray-300 hover:text-white text-sm font-medium rounded-lg transition-colors"
         >
           <BarChart2 className="w-4 h-4 text-blue-400" />
           Interview Progress

--- a/src/components/landing/LandingDemo.tsx
+++ b/src/components/landing/LandingDemo.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Loader2, Sparkles, AlertCircle, ChevronRight } from "lucide-react";
+
+interface DemoResult {
+  role_title: string;
+  seniority_level: string;
+  role_family: string;
+  top_required_skills: string[];
+  nice_to_have_skills: string[];
+  key_responsibilities: string[];
+  what_makes_a_strong_candidate: string;
+  red_flags_to_watch: string[];
+}
+
+export function LandingDemo() {
+  const [jobText, setJobText] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<DemoResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!jobText.trim() || jobText.length < 50) {
+      setError("Paste at least 50 characters of the listing.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const res = await fetch("/api/jobs/demo-analyze", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jobRawText: jobText }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Something went wrong.");
+        return;
+      }
+      setResult(data.analysis);
+    } catch {
+      setError("Network error — try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (result) {
+    return (
+      <div className="w-full rounded-2xl border border-blue-500/30 bg-[#0A0F1C] p-5 text-left space-y-5">
+        {/* Role header */}
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs text-gray-500 font-semibold uppercase tracking-wide">{result.role_family}</p>
+            <h3 className="text-lg font-bold text-white mt-0.5">{result.role_title}</h3>
+            <span className="inline-block mt-1 text-xs font-semibold px-2 py-0.5 rounded-full bg-blue-500/10 text-blue-300 border border-blue-500/20">
+              {result.seniority_level}
+            </span>
+          </div>
+          <button
+            onClick={() => { setResult(null); setJobText(""); }}
+            className="text-xs text-gray-600 hover:text-gray-400 transition-colors shrink-0 mt-1"
+          >
+            Try another
+          </button>
+        </div>
+
+        {/* Required skills */}
+        <div className="space-y-2">
+          <p className="text-xs font-bold text-gray-400 uppercase tracking-wide">Must-have skills</p>
+          <div className="flex flex-wrap gap-2">
+            {result.top_required_skills.map((s) => (
+              <span key={s} className="px-2.5 py-1 rounded-md text-xs font-medium bg-red-500/10 text-red-300 border border-red-500/20">{s}</span>
+            ))}
+          </div>
+        </div>
+
+        {result.nice_to_have_skills.length > 0 && (
+          <div className="space-y-2">
+            <p className="text-xs font-bold text-gray-400 uppercase tracking-wide">Nice to have</p>
+            <div className="flex flex-wrap gap-2">
+              {result.nice_to_have_skills.map((s) => (
+                <span key={s} className="px-2.5 py-1 rounded-md text-xs font-medium bg-amber-500/10 text-amber-300 border border-amber-500/20">{s}</span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Strong candidate */}
+        <div className="rounded-lg bg-green-500/5 border border-green-500/20 p-3">
+          <p className="text-xs font-bold text-green-400 mb-1">What makes a strong candidate</p>
+          <p className="text-sm text-gray-300 leading-relaxed">{result.what_makes_a_strong_candidate}</p>
+        </div>
+
+        {/* Red flags */}
+        {result.red_flags_to_watch.length > 0 && (
+          <div className="rounded-lg bg-orange-500/5 border border-orange-500/20 p-3 space-y-1">
+            <p className="text-xs font-bold text-orange-400 mb-1.5">Watch out for</p>
+            {result.red_flags_to_watch.map((f) => (
+              <p key={f} className="text-xs text-gray-400 flex gap-2 leading-relaxed"><span className="text-orange-400 shrink-0">⚠</span>{f}</p>
+            ))}
+          </div>
+        )}
+
+        {/* CTA to sign up */}
+        <div className="pt-2 border-t border-white/5 flex flex-col sm:flex-row items-center gap-3 justify-between">
+          <p className="text-xs text-gray-500 text-left">
+            Sign up to see how <em>your</em> CV scores against this role — plus interview prep and cover letter.
+          </p>
+          <Link
+            href="/signup"
+            className="shrink-0 flex items-center gap-1.5 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold rounded-lg transition-colors"
+          >
+            Try with my CV <ChevronRight className="w-3.5 h-3.5" />
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="w-full space-y-3">
+      <div className="relative">
+        <textarea
+          rows={4}
+          value={jobText}
+          onChange={(e) => { setJobText(e.target.value); setError(null); }}
+          placeholder="Paste a job listing here — title, description, requirements…"
+          className="w-full rounded-xl border border-[var(--border-subtle)] bg-[#111827]/80 px-4 py-3 text-sm text-white placeholder:text-gray-600 focus:outline-none focus:border-blue-500/60 transition-colors resize-none leading-relaxed"
+        />
+        {jobText.length > 0 && (
+          <span className="absolute bottom-3 right-3 text-[10px] text-gray-600">{jobText.length} chars</span>
+        )}
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 text-xs text-red-400">
+          <AlertCircle className="w-3.5 h-3.5 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={loading || jobText.length < 50}
+        className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed text-white font-semibold rounded-xl transition-colors text-sm shadow-lg shadow-blue-900/30"
+      >
+        {loading ? (
+          <><Loader2 className="w-4 h-4 animate-spin" /> Analysing listing…</>
+        ) : (
+          <><Sparkles className="w-4 h-4" /> Analyse this listing</>
+        )}
+      </button>
+    </form>
+  );
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -15,28 +15,54 @@ import {
   FileEdit,
   ClipboardList,
   BarChart2,
+  ChevronDown,
 } from "lucide-react";
 import { SignOutButton } from "@/components/layout/SignOutButton";
 import { ThemeToggle } from "@/components/layout/ThemeToggle";
 
-const navLinks = [
-  { name: "Dashboard",       href: "/dashboard",     icon: LayoutDashboard },
-  { name: "CV",              href: "/cv",             icon: FileText        },
-  { name: "Job Analyzer",    href: "/jobs",           icon: Briefcase       },
-  { name: "Interview Coach", href: "/interview",      icon: MessageSquare   },
-  { name: "Cover Letter",    href: "/cover-letter",   icon: FileEdit        },
-  { name: "Applications",    href: "/applications",   icon: ClipboardList   },
-  { name: "Career Ladder",   href: "/career",         icon: TrendingUp      },
-  { name: "Analytics",       href: "/analytics",      icon: BarChart2       },
+const primaryLinks = [
+  { name: "Dashboard",       href: "/dashboard",   icon: LayoutDashboard },
+  { name: "Job Analyzer",    href: "/jobs",         icon: Briefcase       },
+  { name: "Applications",    href: "/applications", icon: ClipboardList   },
+  { name: "Interview Coach", href: "/interview",    icon: MessageSquare   },
+];
+
+const secondaryLinks = [
+  { name: "CV Hub",          href: "/cv",           icon: FileText        },
+  { name: "Career Ladder",   href: "/career",       icon: TrendingUp      },
+  { name: "Cover Letter",    href: "/cover-letter", icon: FileEdit        },
+  { name: "Analytics",       href: "/analytics",    icon: BarChart2       },
 ];
 
 export function Sidebar({ userEmail, displayName }: { userEmail: string; displayName: string }) {
   const pathname = usePathname();
   const [isMobileOpen, setIsMobileOpen] = useState(false);
+  const [toolsExpanded, setToolsExpanded] = useState(false);
+
+  const isSecondaryActive = secondaryLinks.some(
+    (l) => pathname === l.href || pathname.startsWith(l.href + "/")
+  );
+
+  const NavLink = ({ href, icon: Icon, name }: { href: string; icon: typeof Briefcase; name: string }) => {
+    const isActive = pathname === href || pathname.startsWith(href + "/");
+    return (
+      <Link
+        href={href}
+        onClick={() => setIsMobileOpen(false)}
+        className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+          isActive
+            ? "bg-blue-600/20 text-blue-400"
+            : "text-gray-400 hover:bg-white/5 hover:text-white"
+        }`}
+      >
+        <Icon className="h-5 w-5 shrink-0" />
+        {name}
+      </Link>
+    );
+  };
 
   const SidebarContent = (
     <div className="flex h-full flex-col justify-between p-4">
-      {/* Top: Logo & Nav */}
       <div>
         <div className="mb-8 px-2 flex items-center h-10">
           <Link
@@ -49,29 +75,35 @@ export function Sidebar({ userEmail, displayName }: { userEmail: string; display
         </div>
 
         <nav className="space-y-1">
-          {navLinks.map((item) => {
-            const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
-            const Icon = item.icon;
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                onClick={() => setIsMobileOpen(false)}
-                className={`flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
-                  isActive
-                    ? "bg-blue-600/20 text-blue-400"
-                    : "text-gray-400 hover:bg-white/5 hover:text-white"
-                }`}
-              >
-                <Icon className="h-5 w-5 shrink-0" />
-                {item.name}
-              </Link>
-            );
-          })}
+          {primaryLinks.map((item) => (
+            <NavLink key={item.href} {...item} />
+          ))}
+
+          {/* Tools group */}
+          <div className="pt-2">
+            <button
+              onClick={() => setToolsExpanded((v) => !v)}
+              className={`w-full flex items-center justify-between px-3 py-2 rounded-lg text-xs font-bold uppercase tracking-widest transition-colors ${
+                isSecondaryActive && !toolsExpanded
+                  ? "text-blue-400"
+                  : "text-gray-600 hover:text-gray-400"
+              }`}
+            >
+              <span>Tools</span>
+              <ChevronDown className={`w-3.5 h-3.5 transition-transform ${toolsExpanded || isSecondaryActive ? "rotate-180" : ""}`} />
+            </button>
+
+            {(toolsExpanded || isSecondaryActive) && (
+              <div className="mt-1 space-y-1 pl-1">
+                {secondaryLinks.map((item) => (
+                  <NavLink key={item.href} {...item} />
+                ))}
+              </div>
+            )}
+          </div>
         </nav>
       </div>
 
-      {/* Settings */}
       <div className="mt-auto pt-4 px-2">
         <Link
           href="/settings"
@@ -88,7 +120,6 @@ export function Sidebar({ userEmail, displayName }: { userEmail: string; display
         <ThemeToggle />
       </div>
 
-      {/* User + Sign Out */}
       <div className="mt-4 border-t border-[#1E3A5F] pt-4">
         <div className="mb-2 px-3 flex flex-col gap-0.5 pointer-events-none">
           <span className="text-sm font-bold text-gray-200 truncate" title={displayName}>


### PR DESCRIPTION
D-1: Landing page rebuild — new hero copy ("Paste a job listing. Know
in 30 seconds if it's worth your time."), working inline demo via
/api/jobs/demo-analyze (IP-rate-limited 1/day, no login required),
three trigger-based scenario cards as primary content, feature grid
demoted below. All inline style={{ }} rules replaced with Tailwind +
CSS vars.

D-2: Auth pages — Google and GitHub OAuth as primary sign-in, magic
link as secondary, email/password collapsed behind a toggle. Signup
simplified: confirm-password removed, display name optional, live
password strength meter added. New /forgot-password page with generic
success message (preserves security stance).

D-3: Sidebar IA — primary group (Dashboard, Job Analyzer, Applications,
Interview Coach) always visible; secondary tools (CV Hub, Career Ladder,
Cover Letter, Analytics) collapsed under a "Tools" toggle. Cover Letter
remains accessible via the job detail page CTA.

D-4: Analytics — replaced remaining hardcoded bg-[#111827] colors in
AnalyticsClient and loading skeleton with bg-[var(--card-bg)] for full
theme compatibility.